### PR TITLE
More robust smoke test script

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     volumes:
       - .:/src
     working_dir: /src
-    ports:
-      - 9443:443
     security_opt:
       - seccomp:unconfined
     network_mode: bridge

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   conjur:
-    image: registry.tld/conjur-appliance-cuke-master:4.9-stable
+    image: registry2.itci.conjur.net/conjur-appliance-cuke-master:4.9-stable
     environment:
       CONJUR_AUTHN_LOGIN: admin
       CONJUR_AUTHN_API_KEY: secret

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   conjur:
-    image: registry2.itci.conjur.net/conjur-appliance-cuke-master:4.9-stable
+    image: registry.tld/conjur-appliance-cuke-master:4.9-stable
     environment:
       CONJUR_AUTHN_LOGIN: admin
       CONJUR_AUTHN_API_KEY: secret

--- a/examples/smoketest.sh
+++ b/examples/smoketest.sh
@@ -21,7 +21,7 @@ export COMPOSE_PROJECT_NAME
 ALL_OK=1
 
 finish() {
-  if [ "$NOKILL" != "0" ]; then
+  if [ "$NOKILL" == "0" ]; then
     rm -f conjur.pem node*.json hftoken.json
     docker-compose down -v
   fi


### PR DESCRIPTION
- Keep going on a failure and only error out at the end.
- Use registry v2 in docker-compose.yml.
- Use unique compose project names to prevent clobbering.