### PR TITLE
Conjur5 API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2017-09-27
+- Support Conjur v5 API.
+
 ## [1.1.0] - 2017-05-24
 - Cleanup and refactor of project files. No behavior change.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,15 +17,17 @@ pipeline {
     }
 
     stage('Run smoke tests') {
-      steps {
-        parallel: (
-          "Conjur v5": {
+      parallel {
+        stage('Test with Conjur v5') {
+          steps {
             dir('examples') {
               sh './smoketest.sh'
             }
-          },
+          }
+        }
 
-          "Conjur Enterprise v4": {
+        stage('Test with Conjur Enterprise v4') {
+          steps {
             dir('examples/ee') {
               sh './smoketest.sh'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,10 +16,20 @@ pipeline {
       }
     }
 
-    stage('Run EC2 smoke test') {
+    stage('Run smoke tests') {
       steps {
-        dir('examples') {
-          sh './smoketest.sh'
+        parallel: (
+          "Conjur v5": {
+            dir('examples') {
+              sh './smoketest.sh'
+            }
+          },
+
+          "Conjur Enterprise v4": {
+            dir('examples/ee') {
+              sh './smoketest.sh'
+            }
+          }
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Description
 
-This is the official Puppet module for [Conjur](https://www.conjur.com), a robust identity and access management platform. This module simplifies the operations of establishing Conjur host identity and allows authorized Puppet nodes to fetch secrets from Conjur.
+This is the official Puppet module for [Conjur](https://www.conjur.org), a robust identity and access management platform. This module simplifies the operations of establishing Conjur host identity and allows authorized Puppet nodes to fetch secrets from Conjur.
 
 ## Setup
 
@@ -145,8 +145,11 @@ To pass a normal string, you need to wrap it using `Sensitive("example")`.
 
 #### Parameters
 
+##### `account`
+Conjur account authority name. Optional for v4, required for v5.
+
 ##### `appliance_url`
-A Conjur endpoint with trailing `/api`.
+A Conjur endpoint (with trailing `/api` for v4).
 
 ##### `authn_login`
 User username or host name (prefixed with `host/`).
@@ -165,6 +168,10 @@ Simply use this parameter to set it. The host record will be created in Conjur.
 ##### `authn_token`
 Raw (unencoded) Conjur token. This is usually only useful for testing.
 Must be `Sensitive` if supported.
+
+##### `version`
+Conjur API version. Defaults to 4.
+Set to 5 if you're using the open source Conjur edition.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ To use a Host Factory token with this module, set variables `authn_login` and `h
 ```puppet
 class { conjur:
   account            => 'mycompany',
-  appliance_url      => 'https://conjur.mycompany.com/api',
+  appliance_url      => 'https://conjur.mycompany.com/',
   authn_login        => 'host/redis001',
   host_factory_token => Sensitive('3zt94bb200p69nanj64v9sdn1e15rjqqt12kf68x1d6gb7z33vfskx'),
   ssl_certificate    => file('/etc/conjur.pem')
+  version            => 5,
 }
 ```
 
@@ -113,10 +114,30 @@ For one-off hosts or test environments it may be preferable to create a host in 
 
 ```puppet
 class { conjur:
-  appliance_url   => 'https://conjur.mycompany.com/api',
+  appliance_url   => 'https://conjur.mycompany.com/',
   authn_login     => 'host/redis001',
   authn_api_key   => Sensitive('f9yykd2r0dajz398rh32xz2fxp1tws1qq2baw4112n4am9x3ncqbk3'),
   ssl_certificate => file('/conjur-ca.pem')
+  version         => 5,
+}
+```
+
+### Conjur Enterprise Edition
+
+If you're using this module to establish host identity with Conjur Enterprise
+Edition version 4.x, you should use `version => 4`. (This is also the default
+for backwards compatibility reasons.) Also note that the `appliance_url` will
+need to include the `/api/` suffix.
+
+For example:
+
+```puppet
+class { conjur:
+  appliance_url      => 'https://conjur.mycompany.com/api/',
+  authn_login        => 'host/redis001',
+  host_factory_token => Sensitive('3zt94bb200p69nanj64v9sdn1e15rjqqt12kf68x1d6gb7z33vfskx'),
+  ssl_certificate    => file('/etc/conjur.pem')
+  version            => 4,
 }
 ```
 
@@ -170,8 +191,9 @@ Raw (unencoded) Conjur token. This is usually only useful for testing.
 Must be `Sensitive` if supported.
 
 ##### `version`
-Conjur API version. Defaults to 4.
-Set to 5 if you're using the open source Conjur edition.
+Conjur API version. Should be set to 5 unless you're using Conjur Enterprise 4.x.
+
+Defaults to 4 for backward compatibility reasons. (This will change in a future version.)
 
 #### Examples
 
@@ -181,10 +203,11 @@ include conjur
 
 # using an host factory token
 class { conjur:
-  appliance_url      => 'https://conjur.mycompany.com/api',
+  appliance_url      => 'https://conjur.mycompany.com/',
   authn_login        => 'host/redis001',
   host_factory_token => Sensitive('f9yykd2r0dajz398rh32xz2fxp1tws1qq2baw4112n4am9x3ncqbk3'),
   ssl_certificate    => file('conjur-ca.pem')
+  version            => 5,
 }
 
 # same, but /etc/conjur.conf and certificate are already on a host
@@ -196,10 +219,12 @@ class { conjur:
 
 # using an API key
 class { conjur:
-  appliance_url   => 'https://conjur.mycompany.com/api',
+  account         => 'mycompany',
+  appliance_url   => 'https://conjur.mycompany.com/',
   authn_login     => 'host/redis001',
   authn_api_key   => Sensitive('f9yykd2r0dajz398rh32xz2fxp1tws1qq2baw4112n4am9x3ncqbk3'),
   ssl_certificate => file('conjur-ca.pem')
+  version         => 5,
 }
 ```
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   conjur:
-    image: cyberark/conjur:0.1.0-stable
+    image: cyberark/conjur
     environment:
       CONJUR_ADMIN_PASSWORD: secret
       DATABASE_URL: postgres://postgres@db

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,14 +1,24 @@
 version: '2'
 services:
   conjur:
-    image: registry.tld/conjur-appliance-cuke-master:4.9-stable
+    image: cyberark/conjur:0.1.0-stable
     environment:
-      CONJUR_AUTHN_LOGIN: admin
-      CONJUR_AUTHN_API_KEY: secret
-      CONJUR_ACCOUNT: cucumber
+      CONJUR_ADMIN_PASSWORD: secret
+      DATABASE_URL: postgres://postgres@db
+      CONJUR_DATA_KEY: testing//testing//testing//testing//testing=
     volumes:
-      - .:/src
+      - .:/src:ro
     working_dir: /src
-    security_opt:
-      - seccomp:unconfined
-    network_mode: bridge
+    command: server
+    depends_on: [db]
+
+  db:
+    image: postgres:9.3
+
+  cli:
+    environment:
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_APPLIANCE_URL: http://conjur
+    image: conjurinc/cli5
+    entrypoint: sleep
+    command: infinity

--- a/examples/ee/README.md
+++ b/examples/ee/README.md
@@ -1,0 +1,4 @@
+# Enterprise Edition examples
+
+Older version of the same examples as in the upper directory, along with test
+scripts requiring Conjur Enterprise v4.

--- a/examples/ee/docker-compose.yml
+++ b/examples/ee/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  conjur:
+    image: registry.tld/conjur-appliance-cuke-master:4.9-stable
+    environment:
+      CONJUR_AUTHN_LOGIN: admin
+      CONJUR_AUTHN_API_KEY: secret
+      CONJUR_ACCOUNT: cucumber
+    volumes:
+      - .:/src
+    working_dir: /src
+    security_opt:
+      - seccomp:unconfined
+    network_mode: bridge

--- a/examples/ee/policy.yml
+++ b/examples/ee/policy.yml
@@ -1,0 +1,14 @@
+- !policy
+  id: inventory
+  annotations:
+    description: Policy that governs access to the inventory database
+  body:
+    - !variable &db-password db-password
+    - !layer
+    - !host-factory
+      layers: [ !layer ]
+
+    - !permit
+      role: [ !layer ]
+      resource: *db-password
+      privilege: [ read, execute ]

--- a/examples/ee/puppetmaster/code/environments/production/environment.conf
+++ b/examples/ee/puppetmaster/code/environments/production/environment.conf
@@ -1,0 +1,18 @@
+# Each environment can have an environment.conf file. Its settings will only
+# affect its own environment. See docs for more info:
+# https://docs.puppetlabs.com/puppet/latest/reference/config_file_environment.html
+
+# Any unspecified settings use default values; some of those defaults are based
+# on puppet.conf settings.
+
+# If these settings include relative file paths, they'll be resolved relative to
+# this environment's directory.
+
+# Allowed settings and default values:
+
+# modulepath = ./modules:$basemodulepath
+# manifest = (default_manifest from puppet.conf, which defaults to ./manifests)
+# config_version = (no script; Puppet will use the time the catalog was compiled)
+# environment_timeout = (environment_timeout from puppet.conf, which defaults to 0)
+    # Note: unless you have a specific reason, we recommend only setting
+    # environment_timeout in puppet.conf.

--- a/examples/ee/puppetmaster/code/environments/production/hieradata/common.yaml
+++ b/examples/ee/puppetmaster/code/environments/production/hieradata/common.yaml
@@ -1,0 +1,15 @@
+puppet_enterprise::profile::puppetdb::listen_address: '0.0.0.0'
+puppet_enterprise::profile::amq::broker::heap_mb: '96'
+puppet_enterprise::profile::master::java_args:
+  Xmx: '192m'
+  Xms: '32m'
+  'XX:MaxPermSize': '=96m'
+  'XX:PermSize': '=96m'
+puppet_enterprise::profile::puppetdb::java_args:
+  Xmx: '96m'
+  Xms: '32m'
+puppet_enterprise::profile::console::java_args:
+  Xmx: '64m'
+  Xms: '32m'
+puppet_enterprise::profile::console::delayed_job_workers: 1
+puppet_enterprise::profile::database::shared_buffers: '4MB'

--- a/examples/ee/puppetmaster/code/environments/production/manifests/site.pp
+++ b/examples/ee/puppetmaster/code/environments/production/manifests/site.pp
@@ -1,0 +1,18 @@
+File { backup => false }
+
+node default {
+  file { '/tmp/puppet-in-docker':
+    ensure  => present,
+    content => 'This file is for demonstration purposes only',
+  }
+
+  if ($facts['conjur_smoke_test']) {
+    include conjur
+    $secret = conjur::secret('inventory/db-password')
+    notify {"Writing this secret to file: ${secret.unwrap}":}
+    file { '/tmp/test.pem':
+      ensure  => file,
+      content => conjur::secret('inventory/db-password'),
+    }
+  }
+}

--- a/examples/ee/puppetmaster/code/hiera.yaml
+++ b/examples/ee/puppetmaster/code/hiera.yaml
@@ -1,0 +1,13 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - "nodes/%{::trusted.certname}"
+  - common
+
+:yaml:
+# datadir is empty here, so hiera uses its defaults:
+# - /etc/puppetlabs/code/environments/%{environment}/hieradata on *nix
+# - %CommonAppData%\PuppetLabs\code\environments\%{environment}\hieradata on Windows
+# When specifying a datadir, make sure the directory exists.
+  :datadir:

--- a/examples/ee/puppetmaster/docker-compose.yml
+++ b/examples/ee/puppetmaster/docker-compose.yml
@@ -1,0 +1,62 @@
+version: "2"
+
+services:
+  puppet:
+    container_name: puppet
+    hostname: puppet
+    image: puppet/puppetserver
+    ports:
+      - 8140
+    volumes:
+      - ./code:/etc/puppetlabs/code/
+      - ../../.:/etc/puppetlabs/code/environments/production/modules/conjur
+    # In some environments puppetdb host gets cert for puppetdb.local.
+    # Make sure the connection works either way.
+    environment:
+      - PUPPETDB_SERVER_URLS=https://puppetdb.local:8081,https://puppetdb:8081
+    links:
+      - puppetdb:puppetdb.local
+
+  puppetdbpostgres:
+    container_name: postgres
+    image: puppet/puppetdb-postgres
+    environment:
+      - POSTGRES_PASSWORD=puppetdb
+      - POSTGRES_USER=puppetdb
+      - POSTGRES_DB=puppetdb
+    expose:
+      - 5432
+
+  puppetdb:
+    container_name: puppetdb
+    hostname: puppetdb
+    image: puppet/puppetdb
+    ports:
+      - 8080
+      - 8081
+
+  puppetboard:
+    image: puppet/puppetboard
+    ports:
+      - 8081:8000
+
+  puppetexplorer:
+    container_name: puppetexplorer
+    image: puppet/puppetexplorer
+    ports:
+      - 8080:80
+    read_only: true
+
+  conjur:
+    hostname: conjur
+    image: registry.tld/conjur-appliance-cuke-master:4.9-stable
+    environment:
+      CONJUR_AUTHN_LOGIN: admin
+      CONJUR_AUTHN_API_KEY: secret
+      CONJUR_ACCOUNT: cucumber
+    ports:
+      - 9443:443
+    volumes:
+      - .:/src
+    security_opt:
+      - seccomp:unconfined

--- a/examples/ee/puppetmaster/policy.yml
+++ b/examples/ee/puppetmaster/policy.yml
@@ -1,0 +1,14 @@
+- !policy
+  id: inventory
+  annotations:
+    description: Policy that governs access to the inventory database
+  body:
+    - !variable &db-password db-password
+    - !layer
+    - !host-factory
+      layers: [ !layer ]
+
+    - !permit
+      role: [ !layer ]
+      resource: *db-password
+      privilege: [ read, execute ]

--- a/examples/ee/puppetmaster/smoketest_e2e.sh
+++ b/examples/ee/puppetmaster/smoketest_e2e.sh
@@ -1,0 +1,67 @@
+#!/bin/bash -e
+
+# Launches a full Puppet stack and converges a node against it
+
+main() {
+  startServices
+  setupConjur
+  convergeNode
+}
+
+runInConjur() {
+  docker-compose exec -T conjur "$@"
+}
+
+startServices() {
+  docker-compose up -d
+}
+
+setupConjur() {
+  runInConjur /opt/conjur/evoke/bin/wait_for_conjur > /dev/null
+  runInConjur cat /opt/conjur/etc/ssl/ca.pem > conjur.pem
+
+  runInConjur conjur policy load --as-group security_admin /src/policy.yml
+  runInConjur conjur variable values add inventory/db-password D7JGyGmCbDNCKYxgvpzz  # load the secret's value
+}
+
+convergeNode() {
+  local node_name='node01'
+
+  runInConjur bash -c "[ -f node.json ] || conjur host create --as-group security_admin $node_name 1> node.json 2>/dev/null"
+  runInConjur bash -c "conjur resource annotate host:$node_name puppet true"
+  runInConjur bash -c "conjur layer hosts add inventory $node_name 2>/dev/null"
+
+  local login="host/$node_name"
+  local api_key=$(runInConjur jq -r '.api_key' node.json | tr -d '\r')
+
+  # write the conjurize files to a tempdir so they can be mounted
+  TMPDIR="$PWD/tmp"
+  mkdir -p $TMPDIR
+
+  local config_file="$TMPDIR/conjur.conf"
+  local identity_file="$TMPDIR/conjur.identity"
+
+  echo "
+    appliance_url: https://conjur/api
+    cert_file: /src/conjur.pem
+  " > $config_file
+
+  echo "
+    machine conjur
+    login $login
+    password $api_key
+  " > $identity_file
+
+  docker run --rm \
+    --net puppetmaster_default \
+    -e 'FACTER_CONJUR_SMOKE_TEST=true' \
+    -v $config_file:/etc/conjur.conf:ro \
+    -v $identity_file:/etc/conjur.identity:ro \
+    -v $PWD:/src:ro -w /src \
+    puppet/puppet-agent-ubuntu
+
+  rm -rf $TMPDIR
+
+}
+
+main "$@"

--- a/examples/ee/scenario1.pp
+++ b/examples/ee/scenario1.pp
@@ -1,0 +1,17 @@
+# Scenario 1: Fetch a secret given a host name and API key
+
+class { 'conjur':
+  appliance_url   => $facts['appliance_url'],
+  authn_login     => $facts['authn_login'],
+  authn_api_key   => Sensitive($facts['authn_api_key']),
+  ssl_certificate => $facts['ssl_certificate']
+}
+
+$secret = conjur::secret('inventory/db-password')
+
+notify {"Writing this secret to file: ${secret.unwrap}":}
+
+file { '/tmp/test.pem':
+  ensure  => file,
+  content => conjur::secret('inventory/db-password'),
+}

--- a/examples/ee/scenario2.5.pp
+++ b/examples/ee/scenario2.5.pp
@@ -1,0 +1,19 @@
+# Scenario 2.5: Fetch a secret given a host name and Host Factory token
+# Not using Sensitive type, to test for Puppet 4.5 support
+
+class { 'conjur':
+  appliance_url      => $facts['appliance_url'],
+  authn_login        => $facts['authn_login'],
+  host_factory_token => $facts['host_factory_token'],
+  ssl_certificate    => $facts['ssl_certificate']
+}
+
+$secret = conjur::secret('inventory/db-password')
+
+notify {"Writing this secret to file: ${secret}":}
+
+file { '/tmp/test.pem':
+  ensure    => file,
+  content   => conjur::secret('inventory/db-password'),
+  show_diff => false
+}

--- a/examples/ee/scenario2.pp
+++ b/examples/ee/scenario2.pp
@@ -1,0 +1,17 @@
+# Scenario 2: Fetch a secret given a host name and Host Factory token
+
+class { 'conjur':
+  appliance_url      => $facts['appliance_url'],
+  authn_login        => $facts['authn_login'],
+  host_factory_token => Sensitive($facts['host_factory_token']),
+  ssl_certificate    => $facts['ssl_certificate']
+}
+
+$secret = conjur::secret('inventory/db-password')
+
+notify {"Writing this secret to file: ${secret.unwrap}":}
+
+file { '/tmp/test.pem':
+  ensure  => file,
+  content => conjur::secret('inventory/db-password'),
+}

--- a/examples/ee/scenario3.pp
+++ b/examples/ee/scenario3.pp
@@ -1,0 +1,13 @@
+# Scenario 4: Fetch a secret given a host name and API key,
+# with preconfigured Conjur identity
+
+include conjur
+
+$secret = conjur::secret('inventory/db-password')
+
+notify {"Writing this secret to file: ${secret.unwrap}":}
+
+file { '/tmp/test.pem':
+  ensure  => file,
+  content => conjur::secret('inventory/db-password'),
+}

--- a/examples/ee/smoketest.sh
+++ b/examples/ee/smoketest.sh
@@ -8,7 +8,7 @@ OSES=(
   debian
 )
 
-COMPOSE_PROJECT_NAME=puppet-smoketest
+COMPOSE_PROJECT_NAME=puppet-v4-smoketest
 
 # make sure on Jenkins if something goes wrong the
 # build doesn't fail because of leftovers from previous tries

--- a/examples/ee/smoketest.sh
+++ b/examples/ee/smoketest.sh
@@ -98,10 +98,10 @@ scenario1() {
     -e FACTER_AUTHN_API_KEY="$api_key" \
     -e FACTER_APPLIANCE_URL='https://conjur/api' \
     -e FACTER_SSL_CERTIFICATE="$(cat conjur.pem)" \
-    -v "$PWD/../:/src/conjur" -w /src/conjur \
+    -v "$PWD/../../:/src/conjur" -w /src/conjur \
     --link $conjur_container:conjur \
     puppet/puppet-agent-$os:latest \
-    apply --modulepath=/src examples/scenario1.pp
+    apply --modulepath=/src examples/ee/scenario1.pp
 }
 
 scenario2() {
@@ -128,10 +128,10 @@ scenario2() {
     -e FACTER_HOST_FACTORY_TOKEN="$host_factory_token" \
     -e FACTER_APPLIANCE_URL='https://conjur/api' \
     -e FACTER_SSL_CERTIFICATE="$(cat conjur.pem)" \
-    -v "$PWD/../:/src/conjur" -w /src/conjur \
+    -v "$PWD/../../:/src/conjur" -w /src/conjur \
     --link $conjur_container:conjur \
     puppet/puppet-agent-$os:$tag \
-    apply --modulepath=/src examples/$manifest
+    apply --modulepath=/src examples/ee/$manifest
 }
 
 scenario3() {
@@ -158,7 +158,7 @@ scenario3() {
 
   echo "
     appliance_url: https://conjur/api
-    cert_file: /src/conjur/examples/conjur.pem
+    cert_file: /src/conjur/examples/ee/conjur.pem
   " > $config_file
 
   echo "
@@ -170,10 +170,10 @@ scenario3() {
   docker run --rm \
     -v $config_file:/etc/conjur.conf:ro \
     -v $identity_file:/etc/conjur.identity:ro \
-    -v "$PWD/../:/src/conjur" -w /src/conjur \
+    -v "$PWD/../../:/src/conjur" -w /src/conjur \
     --link $conjur_container:conjur \
     puppet/puppet-agent-$os:latest \
-    apply --modulepath=/src examples/scenario3.pp
+    apply --modulepath=/src examples/ee/scenario3.pp
 
   rm -rf $TMPDIR
 }
@@ -197,7 +197,7 @@ scenario4() {
   local conjur_container=$(docker-compose ps -q conjur)
 
   docker run --rm -i \
-    -v "$PWD/../:/src/conjur" -w /src/conjur \
+    -v "$PWD/../../:/src/conjur" -w /src/conjur \
     --link $conjur_container:conjur \
     --entrypoint sh \
     -e FACTER_AUTHN_LOGIN="$login" \
@@ -206,8 +206,8 @@ scenario4() {
     -e FACTER_SSL_CERTIFICATE="$(cat conjur.pem)" \
     puppet/puppet-agent-$os:$tag <<< \
     "
-      puppet apply --modulepath=/src examples/scenario2.pp &&
-      puppet apply --modulepath=/src examples/scenario3.pp
+      puppet apply --modulepath=/src examples/ee/scenario2.pp &&
+      puppet apply --modulepath=/src examples/ee/scenario3.pp
     "
 }
 

--- a/examples/ee/smoketest.sh
+++ b/examples/ee/smoketest.sh
@@ -1,0 +1,214 @@
+#!/bin/bash -e
+
+NOKILL=${NOKILL:-"0"}
+
+OSES=(
+  ubuntu
+  centos
+  debian
+)
+
+COMPOSE_PROJECT_NAME=puppet-smoketest
+
+# make sure on Jenkins if something goes wrong the
+# build doesn't fail because of leftovers from previous tries
+if [ -n "$BUILD_NUMBER" ]; then
+   COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME-$BUILD_NUMBER
+fi
+
+export COMPOSE_PROJECT_NAME
+
+ALL_OK=1
+
+finish() {
+  if [ "$NOKILL" == "0" ]; then
+    rm -f conjur.pem node*.json hftoken.json
+    docker-compose down -v
+  fi
+  test $ALL_OK -eq 1 || exit 1
+}
+
+try() {
+  if ! ("$@"); then
+    echo "\"$*\" failed"
+    ALL_OK=0
+  fi
+}
+
+trap finish EXIT
+
+main() {
+  echo "-----"
+  echo "Conjur Puppet Smoke Tests"
+  echo "-----"
+
+  setup_conjur
+
+  for os in "${OSES[@]}"; do
+    for i in $(seq 4); do
+      try scenario$i $os
+    done
+  done
+
+  echo "-----"
+  echo "Running Scenario 2 against Puppet agent 4.5"
+  echo "This is required because the 'Sensitive' type is only supported in Puppet >= 4.6"
+  echo "-----"
+
+  # tag 1.5.2 of the puppet-agent-ubuntu image has Puppet 4.5 installed
+  try scenario2 ubuntu 1.5.2 scenario2.5.pp
+}
+
+runInConjur() {
+  docker-compose exec -T conjur "$@"
+}
+
+setup_conjur() {
+  echo "Starting Conjur"
+  echo "-----"
+  docker-compose up -d conjur
+  runInConjur /opt/conjur/evoke/bin/wait_for_conjur > /dev/null
+  runInConjur cat /opt/conjur/etc/ssl/ca.pem > conjur.pem
+
+  echo "-----"
+  echo "Loading Conjur policy"
+  echo "-----"
+  runInConjur conjur policy load --as-group security_admin policy.yml
+  runInConjur conjur variable values add inventory/db-password D7JGyGmCbDNCKYxgvpzz  # load the secret's value
+}
+
+scenario1() {
+  local os="$1"
+
+  echo "-----"
+  echo "Scenario 1: Fetch a secret given a host name and API key"
+  echo "OS: $os"
+  echo "-----"
+  local node_name='puppet-node01'
+
+  runInConjur bash -c "[ -f node.json ] || conjur host create --as-group security_admin $node_name 1> node.json 2>/dev/null"
+  runInConjur bash -c "conjur layer hosts add inventory $node_name 2>/dev/null"
+
+  local login="host/$node_name"
+  local api_key=$(runInConjur jq -r '.api_key' node.json | tr -d '\r')
+  local conjur_container=$(docker-compose ps -q conjur)
+
+  docker run --rm \
+    -e FACTER_AUTHN_LOGIN="$login" \
+    -e FACTER_AUTHN_API_KEY="$api_key" \
+    -e FACTER_APPLIANCE_URL='https://conjur/api' \
+    -e FACTER_SSL_CERTIFICATE="$(cat conjur.pem)" \
+    -v "$PWD/../:/src/conjur" -w /src/conjur \
+    --link $conjur_container:conjur \
+    puppet/puppet-agent-$os:latest \
+    apply --modulepath=/src examples/scenario1.pp
+}
+
+scenario2() {
+  local os="$1"
+  local tag=${2:-latest}
+  local manifest=${3:-scenario2.pp}
+
+  echo "-----"
+  echo "Scenario 2: Fetch a secret given a host name and Host Factory token"
+  echo "OS: $os"
+  echo "Tag: $tag"
+  echo "Manifest: $manifest"
+  echo "-----"
+  local node_name='puppet-node02'
+
+  runInConjur bash -c "[ -f hftoken.json ] || conjur hostfactory tokens create inventory 1> hftoken.json"
+
+  local login="host/$node_name"
+  local host_factory_token=$(runInConjur jq -r '.[].token' hftoken.json | tr -d '\r')
+  local conjur_container=$(docker-compose ps -q conjur)
+
+  docker run --rm \
+    -e FACTER_AUTHN_LOGIN="$login" \
+    -e FACTER_HOST_FACTORY_TOKEN="$host_factory_token" \
+    -e FACTER_APPLIANCE_URL='https://conjur/api' \
+    -e FACTER_SSL_CERTIFICATE="$(cat conjur.pem)" \
+    -v "$PWD/../:/src/conjur" -w /src/conjur \
+    --link $conjur_container:conjur \
+    puppet/puppet-agent-$os:$tag \
+    apply --modulepath=/src examples/$manifest
+}
+
+scenario3() {
+  local os="$1"
+
+  echo "-----"
+  echo "Scenario 3: Fetch a secret on a node with existing Conjur identity"
+  echo "OS: $os"
+  echo "-----"
+  local node_name='puppet-node03'
+
+  runInConjur bash -c "[ -f node3.json ] || conjur host create --as-group security_admin $node_name 1> node3.json 2>/dev/null"
+  runInConjur bash -c "conjur layer hosts add inventory $node_name 2>/dev/null"
+
+  local login="host/$node_name"
+  local api_key=$(runInConjur jq -r '.api_key' node3.json | tr -d '\r')
+  local conjur_container=$(docker-compose ps -q conjur)
+
+  TMPDIR="$PWD/tmp"
+  mkdir -p $TMPDIR
+
+  local config_file="$TMPDIR/conjur.conf"
+  local identity_file="$TMPDIR/conjur.identity"
+
+  echo "
+    appliance_url: https://conjur/api
+    cert_file: /src/conjur/examples/conjur.pem
+  " > $config_file
+
+  echo "
+    machine conjur
+    login $login
+    password $api_key
+  " > $identity_file
+
+  docker run --rm \
+    -v $config_file:/etc/conjur.conf:ro \
+    -v $identity_file:/etc/conjur.identity:ro \
+    -v "$PWD/../:/src/conjur" -w /src/conjur \
+    --link $conjur_container:conjur \
+    puppet/puppet-agent-$os:latest \
+    apply --modulepath=/src examples/scenario3.pp
+
+  rm -rf $TMPDIR
+}
+
+scenario4() {
+  local os="$1"
+  local tag=${2:-latest}
+
+  echo "-----"
+  echo "Scenario 4: Fetch a secret given a host name and Host Factory token, then use that identity"
+  echo "OS: $os"
+  echo "Tag: $tag"
+  echo "Manifest: $manifest"
+  echo "-----"
+  local node_name='puppet-node04'
+
+  runInConjur bash -c "[ -f hftoken.json ] || conjur hostfactory tokens create inventory 1> hftoken.json"
+
+  local login="host/$node_name"
+  local host_factory_token=$(runInConjur jq -r '.[].token' hftoken.json | tr -d '\r')
+  local conjur_container=$(docker-compose ps -q conjur)
+
+  docker run --rm -i \
+    -v "$PWD/../:/src/conjur" -w /src/conjur \
+    --link $conjur_container:conjur \
+    --entrypoint sh \
+    -e FACTER_AUTHN_LOGIN="$login" \
+    -e FACTER_HOST_FACTORY_TOKEN="$host_factory_token" \
+    -e FACTER_APPLIANCE_URL='https://conjur/api' \
+    -e FACTER_SSL_CERTIFICATE="$(cat conjur.pem)" \
+    puppet/puppet-agent-$os:$tag <<< \
+    "
+      puppet apply --modulepath=/src examples/scenario2.pp &&
+      puppet apply --modulepath=/src examples/scenario3.pp
+    "
+}
+
+main "$@"

--- a/examples/policy.yml
+++ b/examples/policy.yml
@@ -12,3 +12,11 @@
       role: [ !layer ]
       resource: *db-password
       privilege: [ read, execute ]
+
+    - &hosts
+      - !host /puppet-node01
+      - !host /puppet-node03
+
+    - !grant
+      role: !layer
+      member: *hosts

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -48,15 +48,24 @@ services:
     read_only: true
 
   conjur:
-    hostname: conjur
-    image: registry.tld/conjur-appliance-cuke-master:4.9-stable
+    image: cyberark/conjur:0.1.0-stable
     environment:
-      CONJUR_AUTHN_LOGIN: admin
-      CONJUR_AUTHN_API_KEY: secret
-      CONJUR_ACCOUNT: cucumber
-    ports:
-      - 9443:443
+      CONJUR_ADMIN_PASSWORD: secret
+      DATABASE_URL: postgres://postgres@db
+      CONJUR_DATA_KEY: testing//testing//testing//testing//testing=
     volumes:
-      - .:/src
-    security_opt:
-      - seccomp:unconfined
+      - .:/src:ro
+    working_dir: /src
+    command: server
+    depends_on: [db]
+
+  db:
+    image: postgres:9.3
+
+  cli:
+    environment:
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_APPLIANCE_URL: http://conjur
+    image: conjurinc/cli5
+    entrypoint: sleep
+    command: infinity

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     read_only: true
 
   conjur:
-    image: cyberark/conjur:0.1.0-stable
+    image: cyberark/conjur
     environment:
       CONJUR_ADMIN_PASSWORD: secret
       DATABASE_URL: postgres://postgres@db

--- a/examples/puppetmaster/policy.yml
+++ b/examples/puppetmaster/policy.yml
@@ -12,3 +12,12 @@
       role: [ !layer ]
       resource: *db-password
       privilege: [ read, execute ]
+
+    - !host &h
+      id: /node01
+      annotations:
+        puppet: true
+
+    - !grant
+      role: !layer
+      member: [ *h ]

--- a/examples/puppetmaster/smoketest_e2e.sh
+++ b/examples/puppetmaster/smoketest_e2e.sh
@@ -2,6 +2,17 @@
 
 # Launches a full Puppet stack and converges a node against it
 
+COMPOSE_PROJECT_NAME=puppet-smoketeste2e
+
+# make sure on Jenkins if something goes wrong the
+# build doesn't fail because of leftovers from previous tries
+if [ -n "$BUILD_NUMBER" ]; then
+   COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME-$BUILD_NUMBER
+fi
+
+export COMPOSE_PROJECT_NAME
+NETNAME=${COMPOSE_PROJECT_NAME//-/}_default
+
 main() {
   startServices
   setupConjur
@@ -55,7 +66,7 @@ convergeNode() {
   " > $identity_file
 
   docker run --rm \
-    --net puppetmaster_default \
+    --net $NETNAME \
     -e 'FACTER_CONJUR_SMOKE_TEST=true' \
     -v $config_file:/etc/conjur.conf:ro \
     -v $identity_file:/etc/conjur.identity:ro \

--- a/examples/scenario1.pp
+++ b/examples/scenario1.pp
@@ -1,12 +1,12 @@
 # Scenario 1: Fetch a secret given a host name and API key
 
 class { 'conjur':
-  account => 'cucumber',
+  account         => 'cucumber',
   appliance_url   => $facts['appliance_url'],
   authn_login     => $facts['authn_login'],
   authn_api_key   => Sensitive($facts['authn_api_key']),
   ssl_certificate => $facts['ssl_certificate'],
-  version => Integer($facts['conjur_version'])
+  version         => Integer($facts['conjur_version'])
 }
 
 $secret = conjur::secret('inventory/db-password')

--- a/examples/scenario1.pp
+++ b/examples/scenario1.pp
@@ -1,10 +1,12 @@
 # Scenario 1: Fetch a secret given a host name and API key
 
 class { 'conjur':
+  account => 'cucumber',
   appliance_url   => $facts['appliance_url'],
   authn_login     => $facts['authn_login'],
   authn_api_key   => Sensitive($facts['authn_api_key']),
-  ssl_certificate => $facts['ssl_certificate']
+  ssl_certificate => $facts['ssl_certificate'],
+  version => Integer($facts['conjur_version'])
 }
 
 $secret = conjur::secret('inventory/db-password')

--- a/examples/scenario2.5.pp
+++ b/examples/scenario2.5.pp
@@ -5,7 +5,8 @@ class { 'conjur':
   appliance_url      => $facts['appliance_url'],
   authn_login        => $facts['authn_login'],
   host_factory_token => $facts['host_factory_token'],
-  ssl_certificate    => $facts['ssl_certificate']
+  ssl_certificate    => $facts['ssl_certificate'],
+  version => Integer($facts['conjur_version']),
 }
 
 $secret = conjur::secret('inventory/db-password')

--- a/examples/scenario2.5.pp
+++ b/examples/scenario2.5.pp
@@ -6,7 +6,7 @@ class { 'conjur':
   authn_login        => $facts['authn_login'],
   host_factory_token => $facts['host_factory_token'],
   ssl_certificate    => $facts['ssl_certificate'],
-  version => Integer($facts['conjur_version']),
+  version            => Integer($facts['conjur_version']),
 }
 
 $secret = conjur::secret('inventory/db-password')

--- a/examples/scenario2.pp
+++ b/examples/scenario2.pp
@@ -1,10 +1,12 @@
 # Scenario 2: Fetch a secret given a host name and Host Factory token
 
 class { 'conjur':
+  account => 'cucumber',
   appliance_url      => $facts['appliance_url'],
   authn_login        => $facts['authn_login'],
   host_factory_token => Sensitive($facts['host_factory_token']),
-  ssl_certificate    => $facts['ssl_certificate']
+  ssl_certificate    => $facts['ssl_certificate'],
+  version => Integer($facts['conjur_version']),
 }
 
 $secret = conjur::secret('inventory/db-password')

--- a/examples/scenario2.pp
+++ b/examples/scenario2.pp
@@ -1,12 +1,12 @@
 # Scenario 2: Fetch a secret given a host name and Host Factory token
 
 class { 'conjur':
-  account => 'cucumber',
+  account            => 'cucumber',
   appliance_url      => $facts['appliance_url'],
   authn_login        => $facts['authn_login'],
   host_factory_token => Sensitive($facts['host_factory_token']),
   ssl_certificate    => $facts['ssl_certificate'],
-  version => Integer($facts['conjur_version']),
+  version            => Integer($facts['conjur_version']),
 }
 
 $secret = conjur::secret('inventory/db-password')

--- a/examples/smoketest.sh
+++ b/examples/smoketest.sh
@@ -18,6 +18,7 @@ if [ -n "$BUILD_NUMBER" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME
+NETNAME=${COMPOSE_PROJECT_NAME//-/}_default
 
 ALL_OK=1
 
@@ -108,7 +109,7 @@ scenario1() {
   local api_key=$(runInConjur conjur host rotate_api_key -h $node_name)
 
   docker run --rm \
-    --network puppetsmoketest_default \
+    --network $NETNAME \
     -e FACTER_AUTHN_LOGIN="$login" \
     -e FACTER_CONJUR_VERSION=5 \
     -e FACTER_AUTHN_API_KEY="$api_key" \
@@ -137,7 +138,7 @@ scenario2() {
   local host_factory_token=$(runInConjur jq -r '.[].token' hftoken.json | tr -d '\r')
 
   docker run --rm \
-    --network puppetsmoketest_default \
+    --network $NETNAME \
     -e FACTER_AUTHN_LOGIN="$login" \
     -e FACTER_CONJUR_VERSION=5 \
     -e FACTER_HOST_FACTORY_TOKEN="$host_factory_token" \
@@ -178,7 +179,7 @@ scenario3() {
   " > $identity_file
 
   docker run --rm \
-    --network puppetsmoketest_default \
+    --network $NETNAME \
     -v $config_file:/etc/conjur.conf:ro \
     -v $identity_file:/etc/conjur.identity:ro \
     -v "$PWD/../:/src/conjur" -w /src/conjur \
@@ -206,7 +207,7 @@ scenario4() {
   local host_factory_token=$(runInConjur jq -r '.[].token' hftoken.json | tr -d '\r')
 
   docker run --rm -i \
-    --network puppetsmoketest_default \
+    --network $NETNAME \
     -v "$PWD/../:/src/conjur" -w /src/conjur \
     --entrypoint sh \
     -e FACTER_AUTHN_LOGIN="$login" \

--- a/lib/puppet/functions/conjur/config_yml.rb
+++ b/lib/puppet/functions/conjur/config_yml.rb
@@ -1,0 +1,21 @@
+Puppet::Functions.create_function :'conjur::config_yml' do
+  dispatch :generate do
+    param 'String', :appliance_url
+    param 'Integer', :version
+    optional_param 'Variant[String, Undef]', :account
+    optional_param 'Variant[String, Undef]', :cert_file
+  end
+
+  # so much easier to do this in Ruby than in puppet
+  def generate appliance_url, version, account, cert_file
+    {
+      appliance_url: appliance_url,
+      version: version,
+      account: account,
+      cert_file: cert_file
+    }.map do |key, value|
+      next unless value
+      [key, value].join ": "
+    end.compact.join("\n") + "\n"
+  end
+end

--- a/lib/puppet/functions/conjur/secret.rb
+++ b/lib/puppet/functions/conjur/secret.rb
@@ -4,6 +4,7 @@ Puppet::Functions.create_function :'conjur::secret' do
 
   dispatch :secret do
     param 'Conjur::Endpoint', :client
+    param 'String', :account
     param 'String', :variable_id
     param sensitive.name.split("::").last, :token
   end
@@ -12,13 +13,13 @@ Puppet::Functions.create_function :'conjur::secret' do
     param 'String', :variable_id
   end
 
-  def secret client, id, token
+  def secret client, account, id, token
     token = token.unwrap if token.respond_to? :unwrap
-    sensitive.new client.variable_value id, token
+    sensitive.new client.variable_value account, id, token
   end
 
   def with_defaults id
     scope = closure_scope
-    secret scope['conjur::client'], id, scope['conjur::token']
+    secret scope['conjur::client'], scope['conjur::authn_account'], id, scope['conjur::token']
   end
 end

--- a/lib/puppet/functions/conjur/token.rb
+++ b/lib/puppet/functions/conjur/token.rb
@@ -6,10 +6,18 @@ Puppet::Functions.create_function :'conjur::token' do
     param 'Conjur::Endpoint', :client
     param 'String', :login
     param sensitive.name.split("::").last, :key
+    optional_param 'String', :account
   end
 
-  def from_key client, login, key
+  dispatch :from_key do
+    param 'Conjur::Endpoint', :client
+    param 'String', :login
+    param sensitive.name.split("::").last, :key
+    optional_param 'Undef', :_
+  end
+
+  def from_key client, login, key, account
     key = key.unwrap if key.respond_to? :unwrap
-    sensitive.new client.authenticate login, key
+    sensitive.new client.authenticate login, key, account
   end
 end

--- a/manifests/config_files.pp
+++ b/manifests/config_files.pp
@@ -15,7 +15,7 @@ class conjur::config_files inherits conjur {
       $conjur::appliance_url,
       $conjur::version,
       $conjur::authn_account,
-      $conjur::cert_file
+      $cert_file
     )
   }
 

--- a/manifests/config_files.pp
+++ b/manifests/config_files.pp
@@ -1,9 +1,9 @@
 class conjur::config_files inherits conjur {
-  if $ssl_certificate {
+  if $conjur::ssl_certificate {
     $cert_file = '/etc/conjur.pem'
     file { $cert_file:
       replace => false,
-      content => $ssl_certificate
+      content => $conjur::ssl_certificate
     }
   } else {
     $cert_file = undef
@@ -11,17 +11,22 @@ class conjur::config_files inherits conjur {
 
   file { '/etc/conjur.conf':
     replace => false,
-    content => conjur::config_yml($appliance_url, $version, $authn_account, $cert_file)
+    content => conjur::config_yml(
+      $conjur::appliance_url,
+      $conjur::version,
+      $conjur::authn_account,
+      $conjur::cert_file
+    )
   }
 
 
-  if $api_key {
+  if $conjur::api_key {
     file { '/etc/conjur.identity':
       replace   => false,
       mode      => '0400',
       backup    => false,
       show_diff => false,
-      content   => conjur::netrc($client[uri], $authn_login, $api_key)
+      content   => conjur::netrc($conjur::client[uri], $conjur::authn_login, $conjur::api_key)
     }
   }
 }

--- a/manifests/config_files.pp
+++ b/manifests/config_files.pp
@@ -1,0 +1,27 @@
+class conjur::config_files inherits conjur {
+  if $ssl_certificate {
+    $cert_file = '/etc/conjur.pem'
+    file { $cert_file:
+      replace => false,
+      content => $ssl_certificate
+    }
+  } else {
+    $cert_file = undef
+  }
+
+  file { '/etc/conjur.conf':
+    replace => false,
+    content => conjur::config_yml($appliance_url, $version, $authn_account, $cert_file)
+  }
+
+
+  if $api_key {
+    file { '/etc/conjur.identity':
+      replace   => false,
+      mode      => '0400',
+      backup    => false,
+      show_diff => false,
+      content   => conjur::netrc($client[uri], $authn_login, $api_key)
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,30 +3,26 @@ class conjur (
   Optional[String] $authn_login = $conjur::params::authn_login,
   Optional[String] $ssl_certificate = $conjur::params::ssl_certificate,
 
+  Optional[String] $account = $conjur::params::account,
+  Integer $version = $conjur::params::version,
+
   # NOTE these Anys are for compatibility with Puppet < 4.6, so that
   # Sensitive can be used if supported and Strings if not.
   Optional[Any] $authn_api_key = $conjur::params::authn_api_key,
   Optional[Any] $authn_token = $conjur::params::authn_token,
   Optional[Any] $host_factory_token = $conjur::params::host_factory_token,
 ) inherits conjur::params {
-  $client = conjur::client($appliance_url, $ssl_certificate)
-
-  file { '/etc/conjur.conf':
-    replace => false,
-    content => "appliance_url: ${appliance_url}\ncert_file: /etc/conjur.pem"
-  }
-
-  file { '/etc/conjur.pem':
-    replace => false,
-    content => $ssl_certificate
-  }
+  $client = conjur::client($appliance_url, $version, $ssl_certificate)
 
   if $authn_token {
     $token = $authn_token
+    $authn_account = $account
+    $api_key = undef
   } else {
     if $authn_api_key {
       # otherwise, if we know the API key, use it
       $api_key = $authn_api_key
+      $authn_account = $account
     } elsif $host_factory_token {
       $authn_login_parts = split($authn_login, '/')
       if $authn_login_parts[0] != 'host' {
@@ -36,16 +32,11 @@ class conjur (
         $authn_login_parts[1], $host_factory_token
       )
       $api_key = $host_details[api_key]
+      $authn_account = split($host_details[id], ':')[0]
     }
 
-    file { '/etc/conjur.identity':
-      replace   => false,
-      mode      => '0400',
-      backup    => false,
-      show_diff => false,
-      content   => conjur::netrc($client[uri], $authn_login, $api_key)
-    }
-
-    $token = $client.conjur::token($authn_login, $api_key)
+    $token = $client.conjur::token($authn_login, $api_key, $authn_account)
   }
+
+  require conjur::config_files
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,7 @@
 class conjur::params {
   $conjur_config = $facts['conjur'].lest ||{{}}
 
+  $account = $conjur_config['account']
   $appliance_url = $conjur_config['appliance_url']
   $authn_login = $conjur_config['authn_login']
   $authn_api_key = undef
@@ -11,4 +12,5 @@ class conjur::params {
     $token.conjur::decrypt
   }}
   $host_factory_token = undef
+  $version = $conjur_config['version'].lest || { 4 }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name": "conjur-conjur",
-  "version": "1.1.0",
-  "author": "conjur",
+  "version": "1.2.0",
+  "author": "CyberArk",
   "summary": "Register nodes as Conjur hosts and securely use secrets stored in Conjur",
   "license": "Apache-2.0",
-  "source": "https://github.com/conjur/puppet",
-  "project_page": "https://github.com/conjur/puppet",
-  "issues_url": "https://github.com/conjur/puppet/issues",
+  "source": "https://github.com/cyberark/conjur-puppet",
+  "project_page": "https://github.com/cyberark/conjur-puppet",
+  "issues_url": "https://github.com/cyberark/conjur-puppet/issues",
   "dependencies": [
   ],
   "operatingsystem_support": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,12 +6,13 @@ describe 'conjur' do
       appliance_url: 'https://conjur.test/api',
       authn_login: 'host/test',
       authn_api_key: sensitive('the api key'),
+      account: 'testacct',
       ssl_certificate: 'the cert goes here'
     } end
 
     before do
       allow_calling_puppet_function(:'conjur::token', :from_key) \
-        .with(include('uri' => 'https://conjur.test/api/'), 'host/test', sensitive('the api key'))\
+        .with(include('uri' => 'https://conjur.test/api/'), 'host/test', sensitive('the api key'), 'testacct')\
         .and_return sensitive('the token')
     end
 
@@ -46,9 +47,9 @@ describe 'conjur' do
     before do
       allow_calling_puppet_function(:'conjur::manufacture_host', :create) \
           .with(include('uri' => 'https://conjur.test/api/'), 'test', sensitive('the host factory token'))\
-          .and_return 'api_key' => sensitive('the api key')
+          .and_return 'api_key' => sensitive('the api key'), 'id' => 'testacct:host:test'
       allow_calling_puppet_function(:'conjur::token', :from_key) \
-          .with(include('uri' => 'https://conjur.test/api/'), 'host/test', sensitive('the api key'))\
+          .with(include('uri' => 'https://conjur.test/api/'), 'host/test', sensitive('the api key'), 'testacct')\
           .and_return sensitive('the token')
     end
 

--- a/spec/fixtures/manifests/init.pp
+++ b/spec/fixtures/manifests/init.pp
@@ -1,4 +1,6 @@
 class { 'conjur':
   appliance_url => 'https://conjur.test/api',
-  authn_token   => Sensitive('the token')
+  authn_token   => Sensitive('the token'),
+  account       => 'testacct',
+  version       => $conjur_version
 }

--- a/spec/functions/conjur_secret_spec.rb
+++ b/spec/functions/conjur_secret_spec.rb
@@ -1,22 +1,42 @@
 require 'spec_helper'
 
 describe 'conjur::secret', conjur: :mock do
-  it "fetches the given variable using token from conjur class" do
-    expect_authorized_conjur_get('/api/variables/key/value') \
-        .and_return http_ok 'variable value'
-    expect(subject.execute('key').unwrap).to eq 'variable value'
+  shared_examples "fetching secrets" do
+    it "fetches the given variable using token from conjur class" do
+      expect(subject.execute('key').unwrap).to eq 'variable value'
+    end
+
+    it "correctly encodes the id" do
+      expect(subject.execute('tls/key').unwrap).to eq 'tls key value'
+    end
+
+    it "raises an error if the server returns one" do
+      expect{subject.execute 'bad/tls/key'}.to raise_error Net::HTTPError
+    end
   end
 
-  it "correctly encodes the id" do
-    expect_authorized_conjur_get('/api/variables/tls%2Fkey/value') \
-        .and_return http_ok 'tls key value'
-    expect(subject.execute('tls/key').unwrap).to eq 'tls key value'
+  context "with Conjur v4 API" do
+    before do
+      allow_authorized_conjur_get('/api/variables/key/value') \
+          .and_return http_ok 'variable value'
+      allow_authorized_conjur_get('/api/variables/tls%2Fkey/value') \
+          .and_return http_ok 'tls key value'
+      allow_authorized_conjur_get('/api/variables/bad%2Ftls%2Fkey/value') \
+          .and_return http_unauthorized
+    end
+    include_examples "fetching secrets"
   end
 
-
-  it "raises an error if the server returns one" do
-    expect_authorized_conjur_get('/api/variables/tls%2Fkey/value') \
-        .and_return http_unauthorized
-    expect{subject.execute 'tls/key'}.to raise_error Net::HTTPError
+  context "with Conjur v5 API" do
+    let(:facts) {{ conjur_version: 5 }}
+    before do
+      allow_authorized_conjur_get('/api/secrets/testacct/variable/key') \
+          .and_return http_ok 'variable value'
+      allow_authorized_conjur_get('/api/secrets/testacct/variable/tls/key') \
+          .and_return http_ok 'tls key value'
+      allow_authorized_conjur_get('/api/secrets/testacct/variable/bad/tls/key') \
+          .and_return http_unauthorized
+    end
+    include_examples "fetching secrets"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_doubled_constant_names = true
   end
+  config.default_facts = { conjur_version: 4 }
 end
 
 shared_context "mock conjur connection", conjur: :mock do
@@ -32,6 +33,11 @@ shared_context "mock conjur connection", conjur: :mock do
 
   def expect_authorized_conjur_get path
     expect(conjur_connection).to receive(:get).with path,
+      'Authorization' => 'Token token="dGhlIHRva2Vu"' # "the token" b64d
+  end
+
+  def allow_authorized_conjur_get path
+    allow(conjur_connection).to receive(:get).with path,
       'Authorization' => 'Token token="dGhlIHRva2Vu"' # "the token" b64d
   end
 end

--- a/types/endpoint.pp
+++ b/types/endpoint.pp
@@ -1,4 +1,5 @@
 type Conjur::Endpoint = Struct[{
-  uri => String[1],
-  cert => Optional[String[1]]
+  uri     => String[1],
+  version => Integer,
+  cert    => Optional[String[1]]
 }]


### PR DESCRIPTION
Note these are two separate commits: one brings the v5 support proper, another updates the smoke tests to use v5 (exclusively).

I manually verified that the new code passes the old smoke tests; it'd be nice, however to merge both and have a version switch with v5 being default, so that our Jenkins can run both and anyone can run the ones against v5.