### PR TITLE
Fix hostname

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,12 +24,12 @@ class conjur (
       $api_key = $authn_api_key
       $authn_account = $account
     } elsif $host_factory_token {
-      $authn_login_parts = split($authn_login, '/', 2)
-      if $authn_login_parts[0] != 'host' {
+      $authn_login_parts = split($authn_login, '(.*?)\/(.*)')
+      if $authn_login_parts[1] != 'host' {
         fail('can only create hosts with host factory')
       }
       $host_details = $client.conjur::manufacture_host(
-        $authn_login_parts[1], $host_factory_token
+        $authn_login_parts[2], $host_factory_token
       )
       $api_key = $host_details[api_key]
       $authn_account = split($host_details[id], ':')[0]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@ class conjur (
       $api_key = $authn_api_key
       $authn_account = $account
     } elsif $host_factory_token {
-      $authn_login_parts = $authn_login.split('/',2)
+      $authn_login_parts = split($authn_login, '/', 2)
       if $authn_login_parts[0] != 'host' {
         fail('can only create hosts with host factory')
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@ class conjur (
       $api_key = $authn_api_key
       $authn_account = $account
     } elsif $host_factory_token {
-      $authn_login_parts = split($authn_login, '/')
+      $authn_login_parts = $authn_login.split('/',2)
       if $authn_login_parts[0] != 'host' {
         fail('can only create hosts with host factory')
       }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -46,8 +46,8 @@ describe 'conjur' do
 
     before do
       allow_calling_puppet_function(:'conjur::manufacture_host', :create) \
-          .with(include('uri' => 'https://conjur.test/api/'), 'test', sensitive('the host factory token'))\
-          .and_return 'api_key' => sensitive('the api key'), 'id' => 'testacct:host:test'
+          .with(include('uri' => 'https://conjur.test/api/'), 'prod/test', sensitive('the host factory token'))\
+          .and_return 'api_key' => sensitive('the api key'), 'id' => 'testacct:host:prod/test'
       allow_calling_puppet_function(:'conjur::token', :from_key) \
           .with(include('uri' => 'https://conjur.test/api/'), 'host/prod/test', sensitive('the api key'), 'testacct')\
           .and_return sensitive('the token')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,7 @@ describe 'conjur' do
   context 'with api key' do
     let(:params) do {
       appliance_url: 'https://conjur.test/api',
-      authn_login: 'host/test',
+      authn_login: 'host/prod/test',
       authn_api_key: sensitive('the api key'),
       account: 'testacct',
       ssl_certificate: 'the cert goes here'
@@ -12,7 +12,7 @@ describe 'conjur' do
 
     before do
       allow_calling_puppet_function(:'conjur::token', :from_key) \
-        .with(include('uri' => 'https://conjur.test/api/'), 'host/test', sensitive('the api key'), 'testacct')\
+        .with(include('uri' => 'https://conjur.test/api/'), 'host/prod/test', sensitive('the api key'), 'testacct')\
         .and_return sensitive('the token')
     end
 
@@ -40,7 +40,7 @@ describe 'conjur' do
   context 'with host factory token' do
     let(:params) do {
       appliance_url: 'https://conjur.test/api',
-      authn_login: 'host/test',
+      authn_login: 'host/prod/test',
       host_factory_token: sensitive('the host factory token'),
     } end
 
@@ -49,7 +49,7 @@ describe 'conjur' do
           .with(include('uri' => 'https://conjur.test/api/'), 'test', sensitive('the host factory token'))\
           .and_return 'api_key' => sensitive('the api key'), 'id' => 'testacct:host:test'
       allow_calling_puppet_function(:'conjur::token', :from_key) \
-          .with(include('uri' => 'https://conjur.test/api/'), 'host/test', sensitive('the api key'), 'testacct')\
+          .with(include('uri' => 'https://conjur.test/api/'), 'host/prod/test', sensitive('the api key'), 'testacct')\
           .and_return sensitive('the token')
     end
 
@@ -60,7 +60,7 @@ describe 'conjur' do
     it "stores the configuration and identity on the node" do
       expect(subject).to contain_file('/etc/conjur.conf')
       expect(subject).to contain_file('/etc/conjur.identity').with_content(
-          %r(machine https://conjur.test/api/authn\s+login host/test\s+password the api key)
+          %r(machine https://conjur.test/api/authn\s+login host/prod/test\s+password the api key)
       ).with_mode('0400')
     end
   end


### PR DESCRIPTION
Using a regex instead of a delimiter in order to make sure that the full hostname is sent for the host creation request. 

Connected to #17 