### PR TITLE
Encode API as UTF-16LE to match how Windows UI stores them

### DIFF
--- a/lib/conjur/puppet_module/identity.rb
+++ b/lib/conjur/puppet_module/identity.rb
@@ -43,7 +43,7 @@ module Conjur
 
           WinCred.enumerate_credentials
                   .select { |cred| cred[:target].start_with?(uri.to_s) || cred[:target] == uri.host }
-                  .map { |cred| [cred[:username], cred[:value].force_encoding('utf-8')] }
+                  .map { |cred| [cred[:username], cred[:value].force_encoding('utf-16le').encode('utf-8')] }
                   .first
         end
       end

--- a/lib/conjur/puppet_module/identity.rb
+++ b/lib/conjur/puppet_module/identity.rb
@@ -43,7 +43,7 @@ module Conjur
 
           WinCred.enumerate_credentials
                   .select { |cred| cred[:target].start_with?(uri.to_s) || cred[:target] == uri.host }
-                  .map { |cred| [cred[:username], cred[:value].force_encoding('utf-16le').encode('utf-8')] }
+                  .map { |cred| [cred[:username], cred[:value].encode('utf-8')] }
                   .first
         end
       end

--- a/lib/puppet/provider/credential/wincred.rb
+++ b/lib/puppet/provider/credential/wincred.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:credential).provide(:wincred) do
   end
 
   def value
-    current_value[:value] || :absent
+    current_value[:value].force_encoding('utf-16le') || :absent
   end
 
   def value=(value)

--- a/lib/puppet/provider/credential/wincred.rb
+++ b/lib/puppet/provider/credential/wincred.rb
@@ -39,11 +39,11 @@ Puppet::Type.type(:credential).provide(:wincred) do
   end
 
   def value
-    current_value[:value].force_encoding('utf-8') || :absent
+    current_value[:value] || :absent
   end
 
   def value=(value)
-    current_value[:value] = value.force_encoding('ascii-8bit')
+    current_value[:value] = value.encode('utf-16le').force_encoding('binary')
   end
 
   private
@@ -52,7 +52,7 @@ Puppet::Type.type(:credential).provide(:wincred) do
     WinCred.write_credential(
       target: resource.parameter(:target).value,
       username: resource[:username],
-      value: resource[:value].force_encoding('ascii-8bit')
+      value: resource[:value].encode('utf-16le').force_encoding('binary')
     )
   end
 

--- a/lib/wincred/wincred.rb
+++ b/lib/wincred/wincred.rb
@@ -115,7 +115,7 @@ module WinCred
       {
         target: Conversion.pwchar_to_str(cred.TargetName).encode('utf-8'),
         username: Conversion.pwchar_to_str(cred.UserName).encode('utf-8'),
-        value: (cred.CredentialBlobSize > 0 ? cred.CredentialBlob.to_s : nil)
+        value: (cred.CredentialBlobSize > 0 ? cred.CredentialBlob.to_str(cred.CredentialBlobSize) : nil)
       }
     end
   end

--- a/spec/unit/wincred/wincred_spec.rb
+++ b/spec/unit/wincred/wincred_spec.rb
@@ -43,4 +43,14 @@ describe WinCred, wincred: :mock do
         target: 'some.test', username: 'alice', value: 'secret'
     end
   end
+
+  context 'with UTF-16 encoded credentials' do
+    it 'round-trips them correctly' do
+      password = 'ancient'.encode('utf-16le').force_encoding('binary')
+      WinCred.write_credential \
+        target: 'utf16.test', username: 'ursula', value: password
+      expect(WinCred.read_credential('utf16.test')).to eq \
+        target: 'utf16.test', username: 'ursula', value: password
+    end
+  end
 end


### PR DESCRIPTION
This PR updates how Conjur Puppet encodes the credential values stored in the Windows Credential Manager to use the same encoding (`utf-16le`) that the Windows Cred Manager UI and CLI uses.

This allows the Conjur Puppet integration to read credentials created manually, and not only credentials created by Conjur Puppet directly.