### PR TITLE
Allow using slashes in host names with host factory

### DIFF
--- a/examples/smoketest.sh
+++ b/examples/smoketest.sh
@@ -122,7 +122,7 @@ scenario2() {
   echo "Tag: $tag"
   echo "Manifest: $manifest"
   echo "-----"
-  local node_name='puppet-node02'
+  local node_name='puppet/node02'
 
   runInConjur bash -c "[ -f hftoken.json ] || conjur hostfactory tokens create inventory 1> hftoken.json"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,12 +22,12 @@ class conjur (
       $api_key = $authn_api_key
       $authn_account = $account
     } elsif $host_factory_token {
-      $authn_login_parts = split($authn_login, '/')
-      if $authn_login_parts[0] != 'host' {
+      $host_name = regsubst($authn_login, /^host\//, '')
+      if $authn_login == $host_name { # substitution failed
         fail('can only create hosts with host factory')
       }
       $host_details = $client.conjur::manufacture_host(
-        $authn_login_parts[1], $host_factory_token
+        $host_name, $host_factory_token
       )
       $api_key = $host_details[api_key]
       $authn_account = split($host_details[id], ':')[0]


### PR DESCRIPTION
Also add some tests and modify a smoke test to cover this case.
Fixes #17.