### PR TITLE
Ensure puppet receives strings encoded as UTF-8

### DIFF
--- a/lib/conjur/puppet_module/identity.rb
+++ b/lib/conjur/puppet_module/identity.rb
@@ -43,7 +43,7 @@ module Conjur
 
           WinCred.enumerate_credentials
                   .select { |cred| cred[:target].start_with?(uri.to_s) || cred[:target] == uri.host }
-                  .map { |cred| [cred[:username], cred[:value].encode('utf-8')] }
+                  .map { |cred| [cred[:username], cred[:value].force_encoding('utf-16le').encode('utf-8')] }
                   .first
         end
       end

--- a/lib/puppet/provider/credential/wincred.rb
+++ b/lib/puppet/provider/credential/wincred.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:credential).provide(:wincred) do
   end
 
   def value
-    current_value[:value].force_encoding('utf-16le') || :absent
+    current_value[:value].force_encoding('utf-16le').encode('utf-8') || :absent
   end
 
   def value=(value)


### PR DESCRIPTION
This PR updates the puppet module to make sure that when string values are given to Puppet, that they are UTF-8 encoded. Otherwise Puppet fails to compare the string values propertly.