### PR TITLE
Fix Release Script Errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'metadata-json-lint'
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 1.0.0'
 gem 'puppet-lint', '~> 2.1.0'
-gem 'puppet-blacksmith', '~> 3.4.0'
+gem 'puppet-blacksmith', '~> 4.1.0'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet', git: 'https://github.com/conjur/rspec-puppet.git', tag: 'v2.7.2-support-sensitive'
 gem 'rspec_junit_formatter'

--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,7 @@
 
 docker build -t puppet-test .
 
-summon docker run --rm -it \
+summon docker run --rm \
   -v $PWD:/conjur -w /conjur \
   --env-file @SUMMONENVFILE \
   puppet-test \


### PR DESCRIPTION
This PR corrects 2 issues in the release step for Jenkins:
- Removes the `-it` flag from the Docker command to fix "No TTY" error in Jenkins
- Updates 'puppet-blacksmith' version to fix RestClient OpenSSL `:cipher` key error