### PR TITLE
Update Puppet version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": "5.x"
     }
   ]
 }


### PR DESCRIPTION
Puppet 5 is the requirement for Conjur Puppet 2.0.0, however there is a bug (#44) preventing full operation with Puppet 6.

This PR updates the module manifest to indicate support for Puppet 5 only.