### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.1] - 2019-07-15
+- Update module manifest to include Puppet 5.x requirement
+
 ## [2.0.0] - 2019-07-08
 - Remove support for Puppet older than 4.6.
 - Add support for Windows Puppet agents. See [README.md](README.md#windows) for details.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "cyberark-conjur",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "CyberArk",
   "summary": "Register nodes as Conjur hosts and securely use secrets stored in Conjur",
   "license": "Apache-2.0",


### PR DESCRIPTION
The 2.0.0 module on Puppet Forge cannot be replaced, so push this as a new version.