### PR TITLE
Changes smoketests to use CLI to set initial policy

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment:
       CONJUR_ACCOUNT: cucumber
       CONJUR_APPLIANCE_URL: http://conjur
-    image: conjurinc/cli5
+    image: cyberark/conjur-cli:5
     entrypoint: sleep
     command: infinity
     volumes:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -22,3 +22,5 @@ services:
     image: conjurinc/cli5
     entrypoint: sleep
     command: infinity
+    volumes:
+      - .:/src:ro

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     environment:
       CONJUR_ACCOUNT: cucumber
       CONJUR_APPLIANCE_URL: http://conjur
-    image: conjurinc/cli5
+    image: cyberark/conjur-cli:5
     entrypoint: sleep
     command: infinity
     volumes:

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -69,3 +69,5 @@ services:
     image: conjurinc/cli5
     entrypoint: sleep
     command: infinity
+    volumes:
+      - .:/src:ro

--- a/examples/puppetmaster/smoketest_e2e.sh
+++ b/examples/puppetmaster/smoketest_e2e.sh
@@ -34,9 +34,23 @@ wait_for_conjur() {
 setupConjur() {
   wait_for_conjur
   docker-compose exec -T conjur conjurctl account create cucumber || :
-  docker-compose exec -T conjur conjurctl policy load cucumber /src/policy.yml
+  api_key=$(docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin | tr -d '\r')
+
+  echo "-----"
+  echo "Starting CLI"
+  echo "-----"
+
   docker-compose up -d cli
-  docker-compose exec -T cli conjur authn login -pADmin123!!!! admin
+
+  echo "-----"
+  echo "Logging into the CLI"
+  echo "-----"
+  runInConjur conjur authn login -u admin -p "${api_key}"
+
+  echo "-----"
+  echo "Loading Conjur initial policy"
+  echo "-----"
+  runInConjur conjur policy load root /src/policy.yml
   runInConjur conjur variable values add inventory/db-password D7JGyGmCbDNCKYxgvpzz  # load the secret's value
 }
 


### PR DESCRIPTION
Since most users will setup their servers this way, it was valuable that
we do it too in that manner. With this change, we are also working around
a bug in Conjur that prevents CIDR resources from being properly loaded
through the `conjurctl` command: https://github.com/conjurinc/dap-support/issues/80

Connected to #61 