### PR TITLE
Properly encode spaces in variable names for Conjur v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- We now encode the variable id before retrieving it from Conjur v5. 
+  Spaces are encoded into "%20" and slashes into "%2F"
+  ([cyberark/conjur-puppet#71](https://github.com/cyberark/conjur-puppet/pull/71))
 
 ## [2.0.2] - 2019-12-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - We now encode the variable id before retrieving it from Conjur v5. 
   Spaces are encoded into "%20" and slashes into "%2F"
-  ([cyberark/conjur-puppet#71](https://github.com/cyberark/conjur-puppet/pull/71))
+  ([cyberark/conjur-puppet#72](https://github.com/cyberark/conjur-puppet/issues/72))
 
 ## [2.0.2] - 2019-12-18
 ### Added

--- a/lib/puppet/functions/conjur/client.rb
+++ b/lib/puppet/functions/conjur/client.rb
@@ -88,8 +88,8 @@ Puppet::Functions.create_function :'conjur::client' do
             ['variables', URI.encode_www_form_component(id), 'value']
           when 5
             raise ArgumentError, "account is required for v5" unless account
-            ['secrets', account, 'variable', id]
-          end.join('/')
+            ['secrets', account, 'variable', ERB::Util.url_encode(id)]
+               end.join('/')
         get path, Base64.urlsafe_encode64(token)
       end
 

--- a/spec/functions/conjur_secret_spec.rb
+++ b/spec/functions/conjur_secret_spec.rb
@@ -13,6 +13,10 @@ describe 'conjur::secret', conjur: :mock do
     it "raises an error if the server returns one" do
       expect{subject.execute 'bad/tls/key'}.to raise_error Net::HTTPError
     end
+
+    it "correctly encodes spaces" do
+      expect(subject.execute('var with spaces').unwrap).to eq 'var with spaces value'
+    end
   end
 
   ['Windows', 'RedHat'].each do |os_family|
@@ -25,6 +29,8 @@ describe 'conjur::secret', conjur: :mock do
               .and_return http_ok 'variable value'
           allow_authorized_conjur_get('/api/variables/tls%2Fkey/value') \
               .and_return http_ok 'tls key value'
+          allow_authorized_conjur_get('/api/variables/var+with+spaces/value') \
+              .and_return http_ok 'var with spaces value'
           allow_authorized_conjur_get('/api/variables/bad%2Ftls%2Fkey/value') \
               .and_return http_unauthorized
         end
@@ -36,9 +42,11 @@ describe 'conjur::secret', conjur: :mock do
         before do
           allow_authorized_conjur_get('/api/secrets/testacct/variable/key') \
               .and_return http_ok 'variable value'
-          allow_authorized_conjur_get('/api/secrets/testacct/variable/tls/key') \
+          allow_authorized_conjur_get('/api/secrets/testacct/variable/tls%2Fkey') \
               .and_return http_ok 'tls key value'
-          allow_authorized_conjur_get('/api/secrets/testacct/variable/bad/tls/key') \
+          allow_authorized_conjur_get('/api/secrets/testacct/variable/var%20with%20spaces') \
+              .and_return http_ok 'var with spaces value'
+          allow_authorized_conjur_get('/api/secrets/testacct/variable/bad%2Ftls%2Fkey') \
               .and_return http_unauthorized
         end
         include_examples "fetching secrets"


### PR DESCRIPTION
Connected to #72 

Variable IDs were not encoded at all so in case a user had
a variable with spaces in it, we were not able to retrieve it.

The encoding method we use now encodes spaces into "%20" as required
by the Conjur v5 server. It also encodes slashes into "%2F" as required.

This commit updates the current UTs to expect "%2F" for slashes instead of
actual slashes (both are accepted in the server) and adds a UT for a variable
that has spaces in its name.

This PR doesn't change the behaviour for Conjur v4 as I am not sure what the expected behaviour is. In case there was an error with spaces it is still there. However, as the behaviour didn't change then this PR doesn't add any new errors.