### PR TITLE
Include e2e test in build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
         }
       }
     }
-    
+
     // workaround for Jenkins not fetching tags
     stage('Fetch tags') {
       steps {
@@ -44,7 +44,7 @@ pipeline {
 
     stage('Run smoke tests') {
       parallel {
-        stage('Test with Conjur v5') {
+        stage('Local agent - Conjur v5') {
           steps {
             dir('examples') {
               sh './smoketest.sh'
@@ -52,7 +52,15 @@ pipeline {
           }
         }
 
-        stage('Test with Conjur Enterprise v4') {
+        stage('E2E - Conjur 5') {
+          steps {
+            dir('examples/puppetmaster') {
+              sh './smoketest_e2e.sh'
+            }
+          }
+        }
+
+        stage('Local agent - Conjur v4 EE') {
           steps {
             dir('examples/ee') {
               sh './smoketest.sh'

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 
 services:
   puppet:
-    container_name: puppet
     hostname: puppet
     image: puppet/puppetserver:5.3.7
     ports:
@@ -19,9 +18,11 @@ services:
     depends_on:
       - puppetdbpostgres
       - puppetdb
+    links:
+      - "puppetdbpostgres:postgres"
 
   puppetdbpostgres:
-    container_name: postgres
+    hostname: postgres
     image: puppet/puppetdb-postgres
     environment:
       - POSTGRES_PASSWORD=puppetdb
@@ -31,7 +32,6 @@ services:
       - 5432
 
   puppetdb:
-    container_name: puppetdb
     hostname: puppetdb
     image: puppet/puppetdb
     ports:
@@ -44,7 +44,6 @@ services:
       - 8081:8000
 
   puppetexplorer:
-    container_name: puppetexplorer
     image: puppet/puppetexplorer
     ports:
       - 8080:80

--- a/examples/puppetmaster/smoketest_e2e.sh
+++ b/examples/puppetmaster/smoketest_e2e.sh
@@ -4,13 +4,7 @@ set -euo pipefail
 
 # Launches a full Puppet stack and converges a node against it
 
-COMPOSE_PROJECT_NAME=puppetmaster
-
-# make sure on Jenkins if something goes wrong the
-# build doesn't fail because of leftovers from previous tries
-if [ -n "${BUILD_NUMBER:-}" ]; then
-   COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME-$BUILD_NUMBER
-fi
+COMPOSE_PROJECT_NAME=puppetmaster_$(openssl rand -hex 3)
 
 export COMPOSE_PROJECT_NAME
 NETNAME=${COMPOSE_PROJECT_NAME//-/}_default


### PR DESCRIPTION
This should allow us to find errors that our old tests did not as they only
run with a self-contained local agent.