### PR TITLE
Fix currently-broken build

### DIFF
--- a/examples/ee/puppetmaster/docker-compose.yml
+++ b/examples/ee/puppetmaster/docker-compose.yml
@@ -17,16 +17,6 @@ services:
     links:
       - puppetdb:puppetdb.local
 
-  puppetdbpostgres:
-    container_name: postgres
-    image: puppet/puppetdb-postgres
-    environment:
-      - POSTGRES_PASSWORD=puppetdb
-      - POSTGRES_USER=puppetdb
-      - POSTGRES_DB=puppetdb
-    expose:
-      - 5432
-
   puppetdb:
     container_name: puppetdb
     hostname: puppetdb

--- a/examples/ee/smoketest.sh
+++ b/examples/ee/smoketest.sh
@@ -3,9 +3,8 @@
 NOKILL=${NOKILL:-"0"}
 
 OSES=(
+  alpine
   ubuntu
-  centos
-  debian
 )
 
 COMPOSE_PROJECT_NAME=puppet_v4_smoketest

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -16,20 +16,7 @@ services:
     links:
       - puppetdb:puppetdb.local
     depends_on:
-      - puppetdbpostgres
       - puppetdb
-    links:
-      - "puppetdbpostgres:postgres"
-
-  puppetdbpostgres:
-    hostname: postgres
-    image: puppet/puppetdb-postgres
-    environment:
-      - POSTGRES_PASSWORD=puppetdb
-      - POSTGRES_USER=puppetdb
-      - POSTGRES_DB=puppetdb
-    expose:
-      - 5432
 
   puppetdb:
     hostname: puppetdb

--- a/examples/smoketest.sh
+++ b/examples/smoketest.sh
@@ -4,9 +4,8 @@ NOKILL=${NOKILL:-"0"}
 # FAIL_FAST=yes # to quit on first error
 
 OSES=(
+  alpine
   ubuntu
-  centos
-  debian
 )
 
 COMPOSE_PROJECT_NAME=puppet_smoketest


### PR DESCRIPTION
### What does this PR do?
- Removes no longer available `puppet/puppet-agent-centos`, `puppet/puppet-agent-debian`, and `puppet/puppetdb-postgres` images from use in the repo
- Adds `puppet/puppet-agent-alpine` as a test case

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation