### PR TITLE
44 Fix puppet v6 client methods for CA chain retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for v6 agents (v6 server is still not supported) by using v5- and
+  v6-compatible APIs for CA chain retrieval.
+  [cyberark/conjur-puppet#44](https://github.com/org/repo/issues/44)
 
 ## [2.0.3] - 2020-05-10
 ### Changed
-- We now encode the variable id before retrieving it from Conjur v5. 
+- We now encode the variable id before retrieving it from Conjur v5.
   Spaces are encoded into "%20" and slashes into "%2F"
   ([cyberark/conjur-puppet#72](https://github.com/cyberark/conjur-puppet/issues/72))
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ This is the official Puppet module for [Conjur](https://www.conjur.org), a robus
 
 ### Setup Requirements
 
-This module requires that you have a Conjur endpoint available to the Puppet nodes using this module.
+This module requires that you have:
+- Puppet v5 (or equivalent EE version) server
+- Puppet v5 or v6 agent on the nodes
+- Conjur endpoint available to the Puppet nodes using this module.
 
 ### Beginning with conjur
 

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -18,12 +18,28 @@ services:
     depends_on:
       - puppetdb
 
+  postgres:
+    image: postgres:9.6
+    environment:
+      - POSTGRES_PASSWORD=puppetdb
+      - POSTGRES_USER=puppetdb
+      - POSTGRES_DB=puppetdb
+    expose:
+      - 5432
+
   puppetdb:
     hostname: puppetdb
     image: puppet/puppetdb
+    environment:
+      - PUPPETSERVER_HOSTNAME=puppet
+      - PUPPETDB_POSTGRES_HOSTNAME=postgres
+      - PUPPETDB_PASSWORD=puppetdb
+      - PUPPETDB_USER=puppetdb
     ports:
       - 8080
       - 8081
+    depends_on:
+      - postgres
 
   puppetboard:
     image: puppet/puppetboard

--- a/lib/facter/conjur.rb
+++ b/lib/facter/conjur.rb
@@ -71,8 +71,9 @@ Facter.add :conjur do
     def puppet_certificate
       @puppet_certificate ||= begin
         itc = Puppet::Resource::Catalog.indirection.terminus.class
-        get_ssl_cert itc.server, itc.port,
-            Puppet::SSL::Validator.default_validator.ssl_configuration.ca_chain_file
+        ca_chain_file = Puppet[:ssl_client_ca_auth] || Puppet[:localcacert]
+
+        get_ssl_cert itc.server, itc.port, ca_chain_file
       end
     end
 


### PR DESCRIPTION
### What does this PR do?
- Fixes CA chain retrieval on agents to use both v6 and v5 compatible method
- Adds more test cases to E2E smoketest

### What ticket does this PR close?
Connected to #44 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation