### PR TITLE
91 Fix token decryption in v6 server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added support for v6 servers by using v5- and v6-compatible APIs for token decryption
+  [cyberark/conjur-puppet#91](https://github.com/org/repo/issues/91)
 - Added support for v6 agents (v6 server is still not supported) by using v5- and
   v6-compatible APIs for CA chain retrieval.
   [cyberark/conjur-puppet#44](https://github.com/org/repo/issues/44)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,15 @@ pipeline {
           }
         }
 
-        stage('E2E - Conjur 5') {
+        stage('E2E - Puppet 5 - Conjur 5') {
+          steps {
+            dir('examples/puppetmaster') {
+              sh './smoketest_e2e.sh 5'
+            }
+          }
+        }
+
+        stage('E2E - Puppet 6 - Conjur 5') {
           steps {
             dir('examples/puppetmaster') {
               sh './smoketest_e2e.sh'

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the official Puppet module for [Conjur](https://www.conjur.org), a robus
 ### Setup Requirements
 
 This module requires that you have:
-- Puppet v5 (or equivalent EE version) server
+- Puppet v5 or v6 server (v6 tested only on Linux) _or equivalent EE version_
 - Puppet v5 or v6 agent (v6 tested only on Linux) on the nodes
 - Conjur endpoint available to the Puppet nodes using this module.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is the official Puppet module for [Conjur](https://www.conjur.org), a robus
 
 This module requires that you have:
 - Puppet v5 (or equivalent EE version) server
-- Puppet v5 or v6 agent on the nodes
+- Puppet v5 or v6 agent (v6 tested only on Linux) on the nodes
 - Conjur endpoint available to the Puppet nodes using this module.
 
 ### Beginning with conjur

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 
 services:
   puppet:
-    hostname: puppet
     image: puppet/puppetserver:${PUPPET_SERVER_TAG:-latest}
     ports:
       - 8140
@@ -28,7 +27,6 @@ services:
       - 5432
 
   puppetdb:
-    hostname: puppetdb
     image: puppet/puppetdb
     environment:
       - PUPPETSERVER_HOSTNAME=puppet

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   puppet:
     hostname: puppet
-    image: puppet/puppetserver:5.3.7
+    image: puppet/puppetserver:${PUPPET_SERVER_TAG:-latest}
     ports:
       - 8140
     volumes:

--- a/examples/puppetmaster/smoketest_e2e.sh
+++ b/examples/puppetmaster/smoketest_e2e.sh
@@ -46,7 +46,7 @@ run_in_conjur() {
 }
 
 start_services() {
-  docker-compose up -d
+  docker-compose up -d conjur puppet
 }
 
 wait_for_conjur() {

--- a/examples/puppetmaster/smoketest_e2e.sh
+++ b/examples/puppetmaster/smoketest_e2e.sh
@@ -92,7 +92,7 @@ converge_node() {
   local api_key=$(run_in_conjur conjur host rotate_api_key -h $node_name)
 
   # write the conjurize files to a tempdir so they can be mounted
-  TMPDIR="$PWD/tmp"
+  TMPDIR="$PWD/tmp/$(openssl rand -hex 3)"
   mkdir -p $TMPDIR
 
   local config_file="$TMPDIR/conjur.conf"

--- a/examples/puppetmaster/smoketest_e2e.sh
+++ b/examples/puppetmaster/smoketest_e2e.sh
@@ -4,10 +4,18 @@ set -euo pipefail
 
 # Launches a full Puppet stack and converges a node against it
 
-PUPPET_AGENT_TAGS=(
-  5.5.1
-  latest
-)
+PUPPET_SERVER_TAG=latest
+PUPPET_AGENT_TAGS=( latest )
+if [ "${1:-}" = "5" ]; then
+  PUPPET_SERVER_TAG="5.3.7"
+  PUPPET_AGENT_TAGS=(
+    5.5.1
+    latest
+  )
+fi
+export PUPPET_SERVER_TAG
+
+echo "Using Puppet server '$PUPPET_SERVER_TAG' with agents: '${PUPPET_AGENT_TAGS[@]}'"
 
 OSES=(
   alpine
@@ -25,7 +33,7 @@ cleanup() {
 
 main() {
   cleanup
-  trap cleanup  EXIT
+  trap cleanup EXIT
 
   start_services
   setup_conjur

--- a/lib/puppet/functions/conjur/decrypt.rb
+++ b/lib/puppet/functions/conjur/decrypt.rb
@@ -8,9 +8,24 @@ Puppet::Functions.create_function :'conjur::decrypt' do
   end
 
   def decrypt pkcs7
-    host = Puppet::SSL::Host.localhost
-    key = host.key.content
-    certificate = host.certificate.content
+    certificate = nil
+    key = nil
+
+    # Use Puppet 6+ extraction of cert and key if we can otherwise fall
+    # back to v5 methods
+    if defined?(Puppet::X509) == 'constant'
+      certificate_content = File.read(Puppet[:hostcert])
+      certificate = OpenSSL::X509::Certificate.new(certificate_content)
+
+      cert_provider = Puppet::X509::CertProvider.new
+      key_content = cert_provider.load_private_key(Puppet[:certname])
+      key = OpenSSL::PKey::RSA.new(key_content, '')
+    else
+      host = Puppet::SSL::Host.localhost
+      certificate = host.certificate.content
+      key = host.key.content
+    end
+
     decryptor = OpenSSL::PKCS7.new pkcs7
     sensitive.new decryptor.decrypt key, certificate
   end


### PR DESCRIPTION
### What does this PR do?
- Fixes use of missing APIs for token decryption in v6 server
- Expands the test matrix to test v6 with e2e tests

### What ticket does this PR close?
Connected to #91

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation