### PR TITLE
Update HFT link to point to conjur.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ CMDKEY: Credential added successfully.
 ### Conjur host identity with Host Factory
 
 If pre-establishing host identity is unfeasible, we instead recommend bootstrapping
-Conjur host identity using a [Host Factory](https://developer.conjur.net/reference/services/host_factory)
+Conjur host identity using a [Host Factory](https://docs.conjur.org/Latest/en/Content/Operations/Services/host_factory.html)
 token. Nodes inherit the permissions of the layer for which the Host Factory token
 was generated.
 


### PR DESCRIPTION
Previously the doc was pointing to the old Conjur Enterprise v4 site

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation