### PR TITLE
47 HFT WinCred persistence bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   v6-compatible APIs for CA chain retrieval.
   [cyberark/conjur-puppet#44](https://github.com/org/repo/issues/44)
 
+### Fixed
+- Fix windows credential search for HFT-created identities.
+  [cyberark/conjur-puppet#47](https://github.com/org/repo/issues/47)
+
 ## [2.0.3] - 2020-05-10
 ### Changed
 - We now encode the variable id before retrieving it from Conjur v5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix windows credential search for HFT-created identities.
   [cyberark/conjur-puppet#47](https://github.com/org/repo/issues/47)
+- Fix windows registry exceptions on new HFT-based hosts
+  [cyberark/conjur-puppet#112](https://github.com/org/repo/issues/112)
 
 ## [2.0.3] - 2020-05-10
 ### Changed

--- a/lib/conjur/puppet_module/identity.rb
+++ b/lib/conjur/puppet_module/identity.rb
@@ -30,8 +30,11 @@ module Conjur
               when 'password'
                 password = value if found
               end
+
               return [login, password] if login && password
             end
+
+            warn "Could not find conjur authentication info for host '#{uri}'" if not found
           end
         end
 

--- a/lib/conjur/puppet_module/identity.rb
+++ b/lib/conjur/puppet_module/identity.rb
@@ -41,10 +41,24 @@ module Conjur
 
           require 'wincred/wincred'
 
-          WinCred.enumerate_credentials
-                  .select { |cred| cred[:target].start_with?(uri.to_s) || cred[:target] == uri.host }
-                  .map { |cred| [cred[:username], cred[:value].force_encoding('utf-16le').encode('utf-8')] }
-                  .first
+          Puppet.debug "Finding Conjur credentials in WinCred storage for uri: #{uri}"
+          matching_creds = WinCred.enumerate_credentials.select do |cred|
+            cred[:target].start_with?(uri.to_s) || \
+              cred[:target] == "#{uri.host}:#{uri.port}" || \
+              cred[:target] == uri.host
+          end
+
+          if matching_creds.empty?
+            Puppet.warning "Couldn't find any pre-populated Conjur credentials in WinCred " +
+              "storage for #{uri}"
+            return []
+          end
+
+          # We select the first one if there's multiple matches
+          matching_cred = matching_creds.first
+
+          Puppet.debug "Using Conjur credential '#{matching_cred[:target]}' for identity"
+          [matching_cred[:username], matching_cred[:value].force_encoding('utf-16le').encode('utf-8')]
         end
       end
     end


### PR DESCRIPTION
### What does this PR do?
- Fixes issues with persisting/retrieving HFT-based credentials on Windows hosts (#47)
- Fixes issues on hiera-provisioned HFT-based Windows hosts where a missing registry key was throwing exceptions (#112)
- Adds better logging to Windows-based config/credential fetching
- Adds warnings to missing *nix identities on agents


### What ticket does this PR close?

Connected to #47
Connected to #112

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests
- [x] **TESTS DEFERRED - Now placed in #125** (cc @izgeri)

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation