### PR TITLE
132 Fix build upgrades and remove `rspec-puppet` fork dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'puppetlabs_spec_helper', '>= 1.0.0'
 gem 'puppet-lint', '~> 2.1.0'
 gem 'puppet-blacksmith', '~> 4.1.0'
 gem 'facter', '>= 1.7.0'
-gem 'rspec-puppet', git: 'https://github.com/conjur/rspec-puppet.git', tag: 'v2.7.2-support-sensitive'
+gem 'rspec-puppet', git: 'https://github.com/rodjek/rspec-puppet.git'
 gem 'rspec_junit_formatter'
 
 gem 'rubocop'


### PR DESCRIPTION
There were upstream issues with broken dependencies that we upstreamed a
fix for and because of this we needed to pin to latest (unreleased)
version of `rspec-puppet` gem. In the process, it seems like we also
discovered that our fork was not required as the tests all pass so it
was likely that we just had a fork to have a pre-release features ready
which are now in mainline.

Upstream bug: https://github.com/rodjek/rspec-puppet/issues/796
Upstream fix: https://github.com/rodjek/rspec-puppet/pull/797

### What ticket does this PR close?
Connected to #132

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation