### PR TITLE
Made unit tests run against both Puppet v5 and v6 gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /conjur
 
 COPY Gemfile /conjur/Gemfile
 ARG PUPPET_VERSION
-RUN env PUPPET_VERSION=$PUPPET_VERSION bundle
+RUN env PUPPET_VERSION="$PUPPET_VERSION" bundle
 
 COPY . /conjur

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 # 5.5.1 is the oldest officially supported version as of 2019-04
-puppetversion = ENV['PUPPET_VERSION'].to_s.empty? ? '~> 5.5.1' : ENV['PUPPET_VERSION']
+puppetversion = ENV['PUPPET_VERSION'].to_s.empty? ? '~> 6.17.0' : ENV['PUPPET_VERSION']
 
 gem 'metadata-json-lint'
 gem 'puppet', puppetversion

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,11 +34,33 @@ pipeline {
       }
     }
 
-    stage('Lint and unit test module') {
-      steps {
-        sh './test.sh'
-        junit 'spec/output/rspec.xml'
-        archiveArtifacts artifacts: 'spec/output/rspec.xml', fingerprint: true
+    stage('Linting and unit tests') {
+      parallel {
+        stage('Unit tests - Puppet 6') {
+          steps {
+            sh './test.sh'
+          }
+
+          post {
+            always {
+              junit 'spec/output/rspec.xml'
+              archiveArtifacts artifacts: 'spec/output/rspec.xml', fingerprint: true
+            }
+          }
+        }
+
+        stage('Unit tests - Puppet 5') {
+          steps {
+            sh './test.sh 5'
+          }
+
+          post {
+            always {
+              junit 'spec/output/rspec_puppet5.xml'
+              archiveArtifacts artifacts: 'spec/output/rspec_puppet5.xml', fingerprint: true
+            }
+          }
+        }
       }
     }
 
@@ -92,8 +114,6 @@ pipeline {
         sh './release.sh'
       }
     }
-
-    
   }
 
   post {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,12 @@
 version: '2'
 services:
   test-runner:
-    build: .
+    build:
+      context: .
+      args:
+        - PUPPET_VERSION
+    environment:
+      - CI_SPEC_OPTIONS
+      - PUPPET_VERSION
     volumes:
       - ./spec/output:/conjur/spec/output

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,16 @@
 #!/bin/bash -e
 
 readonly compose_file='docker-compose.test.yml'
+readonly v5_puppet_gem="~> 5.5.21"
+readonly v5_output_xml="spec/output/rspec_puppet5.xml"
+
+if [ "$#" -gt 0 ] && [ "$1" =  "5" ]; then
+  echo "Using Puppet v5 ('$v5_puppet_gem') gem for testing"
+  export PUPPET_VERSION=$v5_puppet_gem
+  export CI_SPEC_OPTIONS="-f RspecJunitFormatter -o '$v5_output_xml' -f progress"
+fi
+
+export COMPOSE_PROJECT_NAME="conjur-puppet_$(openssl rand -hex 3)"
 
 docker-compose -f "$compose_file" build --pull
 docker-compose -f "$compose_file" run --rm test-runner \


### PR DESCRIPTION
Our testing previously only tested against v5 puppet gem and was not a
reliable source of truth towards its fucntionling with puppet v6. This
change now allows `./test.sh` to run both varieties of the versions in
parallel.

### What ticket does this PR close?

N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation