### PR TITLE
Update windows cred example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ examples) and the credential password is the host's API key. This is equivalent 
 
 This may be set using Powershell:
 ```powershell
-> cmdkey /generic:https://conjur.mycompany.com /user:hosts/redis001 /pass
-Enter the password for 'hosts/my-host' to connect to 'https://conjur.net/authn': #
+> cmdkey /generic:https://conjur.mycompany.com /user:host/redis001 /pass
+Enter the password for 'host/my-host' to connect to 'https://conjur.net/authn': #
 {Prompt for API Key}
 
 CMDKEY: Credential added successfully.


### PR DESCRIPTION
s/hosts/host. Hosts in Conjur come with a `host` prefix not `hosts`.

### What does this PR do?
Update README.md

### Notes

Note that when following the previous instructions you end up in a situation where you have the wrong hostname `hosts/node01` which results in an Unauthorized error when an attempt to retrieve the token is made. In the logs of the agent  you get this pretty unhelpful error:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Method call, 'conj
ur::token' parameter 'key' expects a Sensitive[String] value, got Undef (file: /etc/puppetlabs/code/environments/production/modules/conjur/manifests/i
nit.pp, line: 42, column: 35) on node c22611896ec1
```

If you happen to be running the agent in debug mode you might noticed several log lines above that `Unauthorized` is mentioned. As best I can tell this is because we rescue any errors thrown while gathering config (https://github.com/cyberark/conjur-puppet/blob/master/lib/facter/conjur.rb#L105) :
```
Debug: Facter: fact "agent_specified_environment" resolved to null and will not be added.
config
{"appliance_url"=>"http://conjur:8081", "version"=>5, "account"=>"cucumber"}
Debug: Finding Conjur credentials in WinCred storage for uri: http://conjur:8081 
Debug: Using Conjur credential 'http://conjur:8081' for identity
Unauthorized 
Debug: Facter: fact "conjur" has resolved to { 
  appliance_url => "http://conjur:8081",
  version => 5,
  account => "cucumber",
  authn_login => "host/node01"
}.
```
### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation