### PR TITLE
Adds warning that std users must not have write access to WinReg config

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,22 @@ Windows Registry Editor Version 5.00
 "CertFile"="C:\Absolute\Path\To\SslCertificate"
 ```
 
+_**NOTE: It is important from a security perspective to ensure that
+unauthorized, non-administrator users do not have write access to Conjur
+connection settings in the Windows Registry. Disabling write access for
+unauthorized users to these settings will help to prevent potential malicious
+redirection of sensitive Puppet agent messages. Read-only access for
+non-administrator users to Conjur connection information can be confirmed via
+`regedit` on the Windows Desktop, or by running the following command from a
+PowerShell to confirm that only the `ReadKey` flag is set:**_
+
+```powershell
+PS C:\> Get-Acl -Path HKLM:SOFTWARE\CyberArk\Conjur | fl * | Out-String -stream | Select-String "BUIL
+TIN\\Users"
+
+AccessToString          : BUILTIN\Users Allow  ReadKey
+```
+
 Credentials for Conjur are stored in the Windows Credential Manager. The credential
 `Target` is the Conjur appliance URL (e.g. `https://conjur.mycompany.com`).
 The username is the host ID, with a `host/` prefix (e.g. `host/redis001`, as in previous


### PR DESCRIPTION
Adds a bolded warning to the README.md file that if Conjur connection
information is configured in the Windows Registry for a Puppet agent
node, then care must be taken to ensure that non-administrator users
do not have write permissions for these Conjur connection Windows
Registry entries.

Fixes Issue #142

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation