### PR TITLE
149 Fix agent's missing registry entries warning on Windows agents

### DIFF
--- a/lib/conjur/puppet_module/config.rb
+++ b/lib/conjur/puppet_module/config.rb
@@ -36,8 +36,8 @@ module Conjur
               c = reg.map { |name, _type, data|  [name.gsub(/(.)([A-Z])/, '\1_\2').downcase, data] }.to_h
             end
           rescue
-            Puppet.warning "Agent’s registry did not contain path #{REG_KEY_NAME}. If this is the " +
-              "first time using HFTs on this node, this is expected behavior."
+            Puppet.notice "Windows Registry on the agent did not contain path '#{REG_KEY_NAME}'. If " +
+              "this is the first time using server-provided credentials, this is expected behavior."
           end
 
           c['ssl_certificate'] ||= File.read c['cert_file'] if c['cert_file']


### PR DESCRIPTION
### What does this PR do?

The error wording was overall not accurate and in many cases not overly
useful so now we clearly specify that this is something that only
happens on server-provided credentials and the warning has been dialed
down to a notice since this is more common than node-provided
authentication.

### What ticket does this PR close?
Connected to #149 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests
- [x] **Deferred to #117**

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation