### PR TITLE
Adds warning to set Conjur identity file permissions to 600

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ machine conjur.mycompany.com
     password f9yykd2r0dajz398rh32xz2fxp1tws1qq2baw4112n4am9x3ncqbk3
 ```
 
+_**NOTE: The `conjur.conf` and `conjur.identity` files contain sensitive
+         Conjur connection information. Care must be taken to ensure that
+         the file permissions for these files is set to `600` so as to
+         disallow any access to these files by unauthorized (non-root) users
+         on a Linux Puppet agent node.**_
+
 The Conjur Puppet Module will automatically check for these files on your node and use them if they
 are available.
 ##### Using Windows Registry / Windows Credential Manager (Windows agents only)

--- a/examples/puppetmaster/smoketest_e2e.sh
+++ b/examples/puppetmaster/smoketest_e2e.sh
@@ -118,12 +118,14 @@ converge_node() {
     account: cucumber
     cert_file: /etc/ca.crt
   " > $config_file
+  chmod 600 $config_file
 
   echo "
     machine conjur-https
     login $login
     password $api_key
   " > $identity_file
+  chmod 600 $identity_file
 
   for os_name in ${OSES[@]}; do
     for agent_tag in ${PUPPET_AGENT_TAGS[@]}; do


### PR DESCRIPTION
This change adds a warning to the main conjur-puppet README.md file that
the Conjur identity files `conjur.conf` and `conjur.identity` must have
their file permissions set to `600` when these files are manually
configured (pre-provisioned) on a Linux node. This is needed to prevent
access to the sensitive information contained in these files by
unauthorized users on a Linux Puppet agent node.

This change also includes a modification to the
`examples/puppetmaster/smoketest_e2e.sh` script such that the file
permissions for the Conjur identity files for this smoketest are properly
set to `600`.

Addresses Issue #143

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation