### PR TITLE
Clarify cert_file references and machine identity persistence, and clean up README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added support for `cert_file` on Windows and to the `conjur` class.
+- Added support for `cert_file` to the `conjur` class, and on Windows via Windows Registry
+  value named `CertFile`.
   [cyberark/conjur-puppet#113](https://github.com/cyberark/conjur-puppet/issues/113)
 - Added support for v6 servers by using v5- and v6-compatible APIs for token decryption
   [cyberark/conjur-puppet#91](https://github.com/org/repo/issues/91)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ refer often to the following Conjur configuration variables:
 - `host_factory_token`: The Conjur host factory token, provided as a string or using the
   [Puppet file resource type](https://puppet.com/docs/puppet/latest/types/file.html).
 - `cert_file`: The file path for the PEM-encoded x509 CA certificate chain for the DAP
-  instance you are connecting to. This file is read from the Puppet server. This configuration parameter overrides `ssl_certificate`.
+  instance you are connecting to. This file is read from the **Puppet server**. This
+  configuration parameter overrides `ssl_certificate`.
 - `ssl_certificate`: The PEM-encoded x509 CA certificate chain for the DAP instance you
   are connecting to, provided as a string or using the
   [Puppet file resource type](https://puppet.com/docs/puppet/latest/types/file.html).
@@ -202,7 +203,7 @@ conjur::appliance_url: 'https://conjur.mycompany.com/'
 conjur::account: 'myorg'
 conjur::authn_login: 'host/redis001'
 conjur::authn_api_key: 'f9yykd2r0dajz398rh32xz2fxp1tws1qq2baw4112n4am9x3ncqbk3'
-# conjur::cert_file: '/absolute/path/to/conjur-ca.pem'
+# conjur::cert_file: '/absolute/path/to/conjur-ca.pem' # Read from the Puppet server
 conjur::ssl_certificate: |
   -----BEGIN CERTIFICATE-----
   ...
@@ -223,7 +224,7 @@ contains:
 account: myorg
 plugins: []
 appliance_url: https://conjur.mycompany.com
-cert_file: "/absolute/path/to/conjur-ca.pem" # Read from the agent
+cert_file: "/absolute/path/to/conjur-ca.pem" # Read from the Puppet agent
 ```
 
 and a `conjur.identity` file that contains:
@@ -250,7 +251,7 @@ values available to set are:
 |-|-|-|
 | Account | REG_SZ | Conjur account specified during Conjur setup. |
 | ApplianceUrl | REG_SZ | Conjur API endpoint. |
-| CertFile | REG_SZ | File path to public Conjur SSL cert. This file is read from the Puppet agent. Takes precedence over `SslCertificate`. |
+| CertFile | REG_SZ | File path to public Conjur SSL cert. This file is read from the **Puppet agent**. Takes precedence over `SslCertificate`. |
 | SslCertificate | REG_SZ | Public Conjur SSL cert. Overwritten by the contents read from `CertFile` when it is present. |
 | Version | REG_DWORD | Conjur API version. Defaults to `5`. |
 
@@ -322,7 +323,7 @@ class { 'conjur':
   account            => 'myorg',
   authn_login        => 'host/redis001',
   host_factory_token => Sensitive('3zt94bb200p69nanj64v9sdn1e15rjqqt12kf68x1d6gb7z33vfskx'),
-  cert_file          => '/absolute/path/to/conjur.pem'
+  cert_file          => '/absolute/path/to/conjur.pem' # Read from the Puppet server
 }
 ```
 
@@ -345,7 +346,7 @@ conjur::appliance_url: 'https://conjur.mycompany.com/'
 conjur::account: 'myorg'
 conjur::authn_login: 'host/redis001'
 conjur::host_factory_token: '3zt94bb200p69nanj64v9sdn1e15rjqqt12kf68x1d6gb7z33vfskx'
-# conjur::cert_file: '/absolute/path/to/conjur-ca.pem'
+# conjur::cert_file: '/absolute/path/to/conjur-ca.pem' # Read from the Puppet Server
 conjur::ssl_certificate: |
   -----BEGIN CERTIFICATE-----
   ...
@@ -424,7 +425,7 @@ API key for a user or host. Must be `Sensitive` if supported.
 
 ##### `cert_file`
 File path to X509 certificate of the root CA of Conjur, PEM formatted. This file is read
-from the Puppet server. Takes precedence over `ssl_certificate`.  
+from the **Puppet server**. Takes precedence over `ssl_certificate`.
 
 ##### `ssl_certificate`
 Content of the X509 certificate of the root CA of Conjur, PEM formatted.
@@ -480,7 +481,7 @@ class { 'conjur':
   appliance_url   => 'https://conjur.mycompany.com/',
   authn_login     => 'host/redis001',
   authn_api_key   => Sensitive('f9yykd2r0dajz398rh32xz2fxp1tws1qq2baw4112n4am9x3ncqbk3'),
-  cert_file       => '/abslute/path/to/conjur-ca.pem',
+  cert_file       => '/absolute/path/to/conjur-ca.pem', # Read from the Puppet server
   version         => 5
 }
 ```
@@ -521,7 +522,7 @@ issued for the host and never handles long-term credentials.
 - If additionally the host has a Conjur identity pre-configured (ie. API key in
   `/etc/conjur.identity` on Linux or Windows Credentials Manager on Windows), the node
   uses that to authenticate to Conjur. It gets back the standard temporary Conjur token
-  which is encrypted with the Puppet master public TLS key and reported in this fact. This
+  which is encrypted with the Puppet master's public TLS key and reported in this fact. This
   ensures only the master (with the corresponding private key) can decrypt and use it.
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ refer often to the following Conjur configuration variables:
 - `host_factory_token`: The Conjur host factory token, provided as a string or using the
   [Puppet file resource type](https://puppet.com/docs/puppet/latest/types/file.html).
 - `cert_file`: The file path for the PEM-encoded x509 CA certificate chain for the DAP
-  instance you are connecting to. This configuration parameter overrides `ssl_certificate`.
+  instance you are connecting to. This file is read from the Puppet server. This configuration parameter overrides `ssl_certificate`.
 - `ssl_certificate`: The PEM-encoded x509 CA certificate chain for the DAP instance you
   are connecting to, provided as a string or using the
   [Puppet file resource type](https://puppet.com/docs/puppet/latest/types/file.html).
@@ -223,7 +223,7 @@ contains:
 account: myorg
 plugins: []
 appliance_url: https://conjur.mycompany.com
-cert_file: "/absolute/path/to/conjur-ca.pem"
+cert_file: "/absolute/path/to/conjur-ca.pem" # Read from the agent
 ```
 
 and a `conjur.identity` file that contains:
@@ -250,7 +250,7 @@ values available to set are:
 |-|-|-|
 | Account | REG_SZ | Conjur account specified during Conjur setup. |
 | ApplianceUrl | REG_SZ | Conjur API endpoint. |
-| CertFile | REG_SZ | File path to public Conjur SSL cert. Takes precedence over `SslCertificate`. |
+| CertFile | REG_SZ | File path to public Conjur SSL cert. This file is read from the Puppet agent. Takes precedence over `SslCertificate`. |
 | SslCertificate | REG_SZ | Public Conjur SSL cert. Overwritten by the contents read from `CertFile` when it is present. |
 | Version | REG_DWORD | Conjur API version. Defaults to `5`. |
 
@@ -322,7 +322,7 @@ class { 'conjur':
   account            => 'myorg',
   authn_login        => 'host/redis001',
   host_factory_token => Sensitive('3zt94bb200p69nanj64v9sdn1e15rjqqt12kf68x1d6gb7z33vfskx'),
-  cert_file          => file('/absolute/path/to/conjur.pem')
+  cert_file          => '/absolute/path/to/conjur.pem'
 }
 ```
 
@@ -415,8 +415,8 @@ User username or host name (prefixed with `host/`).
 API key for a user or host. Must be `Sensitive` if supported.
 
 ##### `cert_file`
-File path to X509 certificate of the root CA of Conjur, PEM formatted. Takes precedence
-over `ssl_certificte`.
+File path to X509 certificate of the root CA of Conjur, PEM formatted. This file is read
+from the Puppet server. Takes precedence over `ssl_certificate`.  
 
 ##### `ssl_certificate`
 Content of the X509 certificate of the root CA of Conjur, PEM formatted.

--- a/README.md
+++ b/README.md
@@ -391,9 +391,17 @@ include conjur
 
 This class establishes Conjur host identity on the node so that secrets can be
 fetched from Conjur. The identity and Conjur endpoint configuration can be
-pre-configured on a host using `/etc/conjur.conf` and `/etc/conjur.identity`
-(by the way of [`conjur` fact](#conjur-fact)) or provided as parameters. The
-identity can also be bootstrapped using a host factory token.
+pre-configured on a host using `/etc/conjur.conf` and `/etc/conjur.identity` on Linux, or
+Windows Registry and Window Credentials Manager on Windows, (by way of
+[`conjur` fact](#conjur-fact)) or provided as parameters. The identity can also be
+bootstrapped using the host factory token parameter.
+
+When this class is instantiated in such a way that it has access to an API key (`authn_api_key`),
+the identity is persisted on the agent using the same OS specific machine identity
+artifacts as mentioned in the pre-configured case above. This happens when the host
+factory parameter is used since a host's API key is retrieved as part of that flow. _Note
+that when this persistence occurs the `cert_file` parameter is always converted to the
+`ssl_certificate` equivalent for the artifact._
 
 #### Note
 
@@ -510,11 +518,11 @@ issued for the host and never handles long-term credentials.
 
 - If the node is preconfigured with Conjur settings, they're reported in this
   fact and they're used as defaults by the `::conjur` class.
-- If additionally the host has a Conjur identity pre-configured (eg. API key in
-  `/etc/conjur.identity`), node uses that to authenticate to Conjur. It gets back
-  the standard temporary Conjur token which is encrypted with the Puppet master
-  public TLS key and reported in this fact. This ensures only the master (with
-  the corresponding private key) can decrypt and use it.
+- If additionally the host has a Conjur identity pre-configured (ie. API key in
+  `/etc/conjur.identity` on Linux or Windows Credentials Manager on Windows), the node
+  uses that to authenticate to Conjur. It gets back the standard temporary Conjur token
+  which is encrypted with the Puppet master public TLS key and reported in this fact. This
+  ensures only the master (with the corresponding private key) can decrypt and use it.
 
 ## Limitations
 


### PR DESCRIPTION
### What does this PR do?
Clean up and clarify cert_file references in README. It also highlights that all `cert_file` values result in a file being read from the Puppet server and only the Windows registry value named `CertFile` results in a file being read from the Puppet agent.

Add section detailing machine identity persistence in README

### What ticket does this PR close?

#148  #152

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation