### PR TITLE
Updates to enable building and publishing the v2.0.4 module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 # 5.5.1 is the oldest officially supported version as of 2019-04
-puppetversion = ENV['PUPPET_VERSION'].to_s.empty? ? '~> 6.17.0' : ENV['PUPPET_VERSION']
+puppetversion = ENV['PUPPET_VERSION'].to_s.empty? ? '~> 5.5.1' : ENV['PUPPET_VERSION']
 
 gem 'metadata-json-lint'
 gem 'puppet', puppetversion

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,13 @@ pipeline {
       }
     }
 
+    stage('Build') {
+      steps {
+        sh './build.sh'
+        archiveArtifacts 'pkg/'
+      }
+    }
+
     stage('Linting and unit tests') {
       parallel {
         stage('Unit tests - Puppet 6') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
       parallel {
         stage('Unit tests - Puppet 6') {
           steps {
-            sh './test.sh'
+            sh './test.sh 6'
           }
 
           post {
@@ -58,7 +58,7 @@ pipeline {
 
         stage('Unit tests - Puppet 5') {
           steps {
-            sh './test.sh 5'
+            sh './test.sh'
           }
 
           post {

--- a/Rakefile
+++ b/Rakefile
@@ -33,10 +33,7 @@ task :test => [:syntax_validate, :lint, :spec]
 
 desc 'Release the module to Puppet Forge'
 task :release do
-  Rake::Task['module:clean'].invoke
-  sh 'puppet module build .'
-  sh 'ls -lh pkg/*tar.gz'
-  sh 'tar -tvf pkg/cyberark-conjur*.tar.gz'
+  Rake::Task['build'].invoke
   Rake::Task['module:push'].invoke
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -39,3 +39,11 @@ task :release do
   sh 'tar -tvf pkg/cyberark-conjur*.tar.gz'
   Rake::Task['module:push'].invoke
 end
+
+desc 'Build the module'
+task :build do
+  Rake::Task['module:clean'].invoke
+  sh 'puppet module build .'
+  sh 'ls -lh pkg/*tar.gz'
+  sh 'tar -tvf pkg/cyberark-conjur*.tar.gz'
+end

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+# Builds this Puppet module
+
+docker build -t puppet-test .
+
+docker run --rm \
+  -v $PWD:/conjur -w /conjur \
+  puppet-test \
+  bash -c 'bundle --quiet && bundle exec rake build'

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,15 @@
 #!/bin/bash -e
 
 readonly compose_file='docker-compose.test.yml'
-readonly v5_puppet_gem="~> 5.5.21"
 readonly v5_output_xml="spec/output/rspec_puppet5.xml"
 
-if [ "$#" -gt 0 ] && [ "$1" =  "5" ]; then
-  echo "Using Puppet v5 ('$v5_puppet_gem') gem for testing"
-  export PUPPET_VERSION=$v5_puppet_gem
+readonly v6_puppet_gem="~>6.17.0"
+
+if [ "$#" -gt 0 ] && [ "$1" =  "6" ]; then
+  echo "Using Puppet v6 ('$v6_puppet_gem') gem for testing"
+  export PUPPET_VERSION=$v6_puppet_gem
+else
+  echo "Using default Puppet v5 gem for testing"
   export CI_SPEC_OPTIONS="-f RspecJunitFormatter -o '$v5_output_xml' -f progress"
 fi
 


### PR DESCRIPTION
### What does this PR do?
Reverts the Puppet gem in the build pipeline to v5.x to enable publishing. Makes additional minor changes to enable building the module locally.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation