### PR TITLE
Store runtime ssl_certificate in raw_ssl_certificate for conjur class

### DIFF
--- a/manifests/config/files.pp
+++ b/manifests/config/files.pp
@@ -1,11 +1,11 @@
 # Responsible for storing Conjur connection information in a
 # POSIX-based file system.
 class conjur::config::files inherits conjur {
-  if $conjur::ssl_certificate {
+  if $conjur::raw_ssl_certificate {
     $cert_file = '/etc/conjur.pem'
     file { $cert_file:
       replace => false,
-      content => $conjur::ssl_certificate
+      content => $conjur::raw_ssl_certificate
     }
   } else {
     $cert_file = undef

--- a/manifests/config/registry.pp
+++ b/manifests/config/registry.pp
@@ -6,11 +6,11 @@ class conjur::config::registry inherits conjur {
     ensure => present,
   }
 
-  if $conjur::ssl_certificate {
+  if $conjur::raw_ssl_certificate {
     registry_value { 'HKLM\Software\CyberArk\Conjur\SslCertificate':
       ensure => present,
       type   => string,
-      data   => $conjur::ssl_certificate,
+      data   => $conjur::raw_ssl_certificate,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,9 +12,12 @@ class conjur (
   Optional[Sensitive] $host_factory_token = $conjur::params::host_factory_token,
 ) inherits conjur::params {
   if $cert_file {
-    $ssl_certificate = file($cert_file)
+    $raw_ssl_certificate = file($cert_file)
+  } else {
+    $raw_ssl_certificate = $ssl_certificate
   }
-  $client = conjur::client($appliance_url, $version, $ssl_certificate)
+
+  $client = conjur::client($appliance_url, $version, $raw_ssl_certificate)
 
   if $authn_token {
     $token = $authn_token


### PR DESCRIPTION

### What does this PR do?
Puppet variables are immutable once set. To allow the runtime ssl_certificate to be populate by either the ssl_certificate param or cert_file param we need a separate variable that will be consumed at runtime.

### What ticket does this PR close?
Connected to #156 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation