### PR TITLE
Revert "Store runtime ssl_certificate in raw_ssl_certificate for conjur class"

### DIFF
--- a/manifests/config/files.pp
+++ b/manifests/config/files.pp
@@ -1,11 +1,11 @@
 # Responsible for storing Conjur connection information in a
 # POSIX-based file system.
 class conjur::config::files inherits conjur {
-  if $conjur::raw_ssl_certificate {
+  if $conjur::ssl_certificate {
     $cert_file = '/etc/conjur.pem'
     file { $cert_file:
       replace => false,
-      content => $conjur::raw_ssl_certificate
+      content => $conjur::ssl_certificate
     }
   } else {
     $cert_file = undef

--- a/manifests/config/registry.pp
+++ b/manifests/config/registry.pp
@@ -6,11 +6,11 @@ class conjur::config::registry inherits conjur {
     ensure => present,
   }
 
-  if $conjur::raw_ssl_certificate {
+  if $conjur::ssl_certificate {
     registry_value { 'HKLM\Software\CyberArk\Conjur\SslCertificate':
       ensure => present,
       type   => string,
-      data   => $conjur::raw_ssl_certificate,
+      data   => $conjur::ssl_certificate,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,12 +12,9 @@ class conjur (
   Optional[Sensitive] $host_factory_token = $conjur::params::host_factory_token,
 ) inherits conjur::params {
   if $cert_file {
-    $raw_ssl_certificate = file($cert_file)
-  } else {
-    $raw_ssl_certificate = $ssl_certificate
+    $ssl_certificate = file($cert_file)
   }
-
-  $client = conjur::client($appliance_url, $version, $raw_ssl_certificate)
+  $client = conjur::client($appliance_url, $version, $ssl_certificate)
 
   if $authn_token {
     $token = $authn_token


### PR DESCRIPTION
Reverts cyberark/conjur-puppet#157 - we are mid-release cycle for v2.0.4 and are going to hold off on this bug fix until the next version.

Note: this means that #147 and #156 are both outstanding bugs relating to `cert_file` in the v2.0.4 release, so we recommend users continue to use `ssl_certificate` in v2.0.4.