### PR TITLE
DO NOT MERGE YET: Store runtime ssl_certificate in raw_ssl_certificate for conjur class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Resolve bug in `cert_file` parameter logic, in the `conjur` class, that attempts to
-  reassign immutable `$ssl_certificate` Puppet variable.
+- Module no longer throws error when `cert_file` parameter is used in the `conjur` class.
   [cyberark/conjur-puppet#156](https://github.com/cyberark/conjur-puppet/issues/156)
 
 ## [2.0.4] - 2020-07-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Resolve bug in `cert_file` parameter logic, in the `conjur` class, that attempts to
+  reassign immutable `$ssl_certificate` Puppet variable.
+  [cyberark/conjur-puppet#156](https://github.com/cyberark/conjur-puppet/issues/156)
+
 ## [2.0.4] - 2020-07-20
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /conjur
 
 COPY Gemfile /conjur/Gemfile
 ARG PUPPET_VERSION
-RUN env PUPPET_VERSION="$PUPPET_VERSION" bundle
+RUN env PUPPET_VERSION="$PUPPET_VERSION" bundle && cp Gemfile.lock /tmp
 
-COPY . /conjur
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,14 @@ WORKDIR /conjur
 
 COPY Gemfile /conjur/Gemfile
 ARG PUPPET_VERSION
-RUN env PUPPET_VERSION="$PUPPET_VERSION" bundle && cp Gemfile.lock /tmp
+
+ENV PUPPET_VERSION="$PUPPET_VERSION"
+
+# The `Gemfile.lock` created here at build time is stored as `/build-Gemfile.lock` for
+# safe-keeping. `/docker-entrypoint.sh` will copy this file into the working directory,
+# `/conjur/Gemfile.lock`, at runtime to prevent any issues associated with it being
+# overwritten by a volume mount of the `/conjur` working directory.
+RUN bundle && cp Gemfile.lock /build-Gemfile.lock
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN env PUPPET_VERSION="$PUPPET_VERSION" bundle && cp Gemfile.lock /tmp
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
+
+COPY . /conjur

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,4 +10,6 @@ services:
       - PUPPET_VERSION
     volumes:
       - ./spec/output:/conjur/spec/output
-      - ./:/conjur
+# Uncomment below to volume mount source to test-runner. This is particularly convenient
+# during development.
+#      - ./:/conjur

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,3 +10,4 @@ services:
       - PUPPET_VERSION
     volumes:
       - ./spec/output:/conjur/spec/output
+      - ./:/conjur

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,8 +2,12 @@
 
 set -e
 
-# This resolves the issue with a volume mount to `/conjur` overriding the `Gemfile.lock`
+# This resolves the issue of a volume mount to `/conjur` overriding the `Gemfile.lock`
 # from `docker build`.
-cp "/tmp/Gemfile.lock" "Gemfile.lock"
+#
+# `/build-Gemfile.lock` is the `Gemfile.lock` created when bundle is run at build time.
+# Copying this file into the working directory, `/conjur`, at runtime prevents issues
+# associated with it being overwritten by a volume mount.
+cp "/build-Gemfile.lock" "/conjur/Gemfile.lock"
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This resolves the issue with a volume mount to `/conjur` overriding the `Gemfile.lock`
+# from `docker build`.
+cp "/tmp/Gemfile.lock" "Gemfile.lock"
+
+exec "$@"

--- a/manifests/config/files.pp
+++ b/manifests/config/files.pp
@@ -1,11 +1,11 @@
 # Responsible for storing Conjur connection information in a
 # POSIX-based file system.
 class conjur::config::files inherits conjur {
-  if $conjur::ssl_certificate {
+  if $conjur::raw_ssl_certificate {
     $cert_file = '/etc/conjur.pem'
     file { $cert_file:
       replace => false,
-      content => $conjur::ssl_certificate
+      content => $conjur::raw_ssl_certificate
     }
   } else {
     $cert_file = undef

--- a/manifests/config/registry.pp
+++ b/manifests/config/registry.pp
@@ -6,11 +6,11 @@ class conjur::config::registry inherits conjur {
     ensure => present,
   }
 
-  if $conjur::ssl_certificate {
+  if $conjur::raw_ssl_certificate {
     registry_value { 'HKLM\Software\CyberArk\Conjur\SslCertificate':
       ensure => present,
       type   => string,
-      data   => $conjur::ssl_certificate,
+      data   => $conjur::raw_ssl_certificate,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,9 +12,12 @@ class conjur (
   Optional[Sensitive] $host_factory_token = $conjur::params::host_factory_token,
 ) inherits conjur::params {
   if $cert_file {
-    $ssl_certificate = file($cert_file)
+    $raw_ssl_certificate = file($cert_file)
+  } else {
+    $raw_ssl_certificate = $ssl_certificate
   }
-  $client = conjur::client($appliance_url, $version, $ssl_certificate)
+
+  $client = conjur::client($appliance_url, $version, $raw_ssl_certificate)
 
   if $authn_token {
     $token = $authn_token

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,7 +13,6 @@ describe 'conjur' do
           authn_login: 'host/test',
           authn_api_key: sensitive('the api key'),
           account: 'testacct',
-          # cert_file: '/conjur/spec/fixtures/conjur-ca.pem',
           ssl_certificate: 'the cert goes here'
         } end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -144,7 +144,7 @@ describe 'conjur' do
     # `init.pp` is somehow being interpreted as being run on a Windows machine and so the
     # unix path provided below fails absolute path validation. This seems to be an issue
     # with the rspec utilities that simulate the generation of the catalog, as opposed to
-    # the any logic in `init.pp`. Under production circumstances the call to `file()` will
+    # any logic in `init.pp`. Under production circumstances the call to `file()` will
     # always be run on a unix machine (the Puppet server) and so would never fail the
     # absolute path validation.
     #

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -33,7 +33,6 @@ describe 'conjur' do
         it "stores the configuration and identity on the node" do
           if os_family == 'Windows'
             expect(subject).to contain_registry_value('HKLM\Software\CyberArk\Conjur\ApplianceUrl')
-                                   .with("data" => 'https://conjur.test/api')
             expect(subject).to contain_registry_value('HKLM\Software\CyberArk\Conjur\SslCertificate')
             expect(subject).to contain_registry_value('HKLM\Software\CyberArk\Conjur\Account')
             expect(subject).to contain_registry_value('HKLM\Software\CyberArk\Conjur\Version')

--- a/spec/fixtures/conjur-ca.pem
+++ b/spec/fixtures/conjur-ca.pem
@@ -1,0 +1,1 @@
+definitely a ca


### PR DESCRIPTION
### What does this PR do?
Puppet variables are immutable once set. To allow the runtime ssl_certificate to be populate by either the ssl_certificate param or cert_file param we need a separate variable that will be consumed at runtime.

### What ticket does this PR close?
Connected to #156 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation