### PR TITLE
Bump version 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.5] - 2020-07-28
+
+### Added
+- Preliminary support for Puppet 6 with Linux agents, now including Ubuntu 18.04
+  and 20.04, Debian 9 and 10, and Alpine 3.9.
+  [Epic cyberark/conjur-puppet#20](https://github.com/cyberark/conjur-puppet/issues/20)
+
+### Deprecated
+- Support for using the Conjur Puppet module with Conjur Enterprise v4 is now
+  deprecated. Support will be removed in the next major release. The `conjurize`
+  method of providing the Conjur Puppet module with its Conjur identity will
+  also no longer be supported as of the next version.
+- Support for using the Conjur Puppet module with [Windows Server 2008](https://support.microsoft.com/en-us/lifecycle/search?alpha=Windows%20Server%202008)
+  or [Debian 7](https://wiki.debian.org/DebianWheezy) agents, since both
+  operating systems have now reached end of life.
+
 ## [2.0.4] - 2020-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -150,9 +150,6 @@ refer often to the following Conjur configuration variables:
   Conjur / DAP instance.
 - `host_factory_token`: The Conjur host factory token, provided as a string or using the
   [Puppet file resource type](https://puppet.com/docs/puppet/latest/types/file.html).
-- `cert_file`: The file path for the PEM-encoded x509 CA certificate chain for the DAP
-  instance you are connecting to. This file is read from the **Puppet server**. This
-  configuration parameter overrides `ssl_certificate`.
 - `ssl_certificate`: The PEM-encoded x509 CA certificate chain for the DAP instance you
   are connecting to, provided as a string or using the
   [Puppet file resource type](https://puppet.com/docs/puppet/latest/types/file.html).
@@ -209,7 +206,6 @@ conjur::appliance_url: 'https://conjur.mycompany.com/'
 conjur::account: 'myorg'
 conjur::authn_login: 'host/redis001'
 conjur::authn_api_key: 'f9yykd2r0dajz398rh32xz2fxp1tws1qq2baw4112n4am9x3ncqbk3'
-# conjur::cert_file: '/absolute/path/to/conjur-ca.pem' # Read from the Puppet server
 conjur::ssl_certificate: |
   -----BEGIN CERTIFICATE-----
   ...
@@ -263,7 +259,6 @@ values available to set are:
 |-|-|-|
 | Account | REG_SZ | Conjur account specified during Conjur setup. |
 | ApplianceUrl | REG_SZ | Conjur API endpoint. |
-| CertFile | REG_SZ | File path to public Conjur SSL cert. This file is read from the **Puppet agent**. Takes precedence over `SslCertificate`. |
 | SslCertificate | REG_SZ | Public Conjur SSL cert. Overwritten by the contents read from `CertFile` when it is present. |
 | Version | REG_DWORD | Conjur API version. Defaults to `5`. |
 
@@ -351,7 +346,7 @@ class { 'conjur':
   account            => 'myorg',
   authn_login        => 'host/redis001',
   host_factory_token => Sensitive('3zt94bb200p69nanj64v9sdn1e15rjqqt12kf68x1d6gb7z33vfskx'),
-  cert_file          => '/absolute/path/to/conjur.pem' # Read from the Puppet server
+  ssl_certificate    => file('/absolute/path/to/conjur-ca.pem')
 }
 ```
 
@@ -374,7 +369,6 @@ conjur::appliance_url: 'https://conjur.mycompany.com/'
 conjur::account: 'myorg'
 conjur::authn_login: 'host/redis001'
 conjur::host_factory_token: '3zt94bb200p69nanj64v9sdn1e15rjqqt12kf68x1d6gb7z33vfskx'
-# conjur::cert_file: '/absolute/path/to/conjur-ca.pem' # Read from the Puppet Server
 conjur::ssl_certificate: |
   -----BEGIN CERTIFICATE-----
   ...

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ secrets from Conjur.
 
 This module requires that you have:
 - Puppet v5 _or equivalent EE version_
-- Puppet v5 agent on the nodes
+- Puppet v6 _or equivalent EE version_ (**Preliminary [Community level](https://github.com/cyberark/community/blob/master/Conjur/conventions/certification-levels.md#community)
+  support only**)
 - Conjur endpoint available to both the Puppet server and the Puppet nodes using this
   module. Supported versions:
   - Conjur OSS v1+

--- a/README.md
+++ b/README.md
@@ -398,6 +398,10 @@ For a complete reference, please see [REFERENCE.md](REFERENCE.md).
 
 See [metadata.json](metadata.json) for supported platforms.
 
+At current, the Conjur Puppet module encrypts and decrypts the Conjur access
+token using the Puppet server’s private/public key pair. This is known to be
+incompatible with using multiple [compile masters](https://puppet.com/docs/puppetserver/5.3/scaling_puppet_server.html).
+
 ## Contributing
 
 We welcome contributions of all kinds to this repository. For instructions on

--- a/metadata.json
+++ b/metadata.json
@@ -1,32 +1,36 @@
 {
   "name": "cyberark-conjur",
-  "version": "2.0.4",
-  "author": "CyberArk",
+  "version": "2.0.5",
+  "author": "CyberArk Software, Inc.",
   "summary": "Register nodes as Conjur hosts and securely use secrets stored in Conjur",
   "license": "Apache-2.0",
   "source": "https://github.com/cyberark/conjur-puppet",
   "project_page": "https://github.com/cyberark/conjur-puppet",
   "issues_url": "https://github.com/cyberark/conjur-puppet/issues",
+  "tags": ["conjur", "cyberark", "dap", "secrets"],
   "dependencies": [
     { "name":"puppetlabs/registry","version_requirement":">= 2.1.0" }
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "ubuntu",
-      "operatingsystemrelease": ["14.04", "16.04"]
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": ["14.04", "16.04", "18.04", "20.04"]
     },
     {
-      "operatingsystem": "centos",
+      "operatingsystem": "Centos",
       "operatingsystemrelease": ["6", "7"]
     },
     {
-      "operatingsystem": "debian",
-      "operatingsystemrelease": ["7", "8"]
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": ["8", "9", "10"]
+    },
+    {
+      "operatingsystem": "Alpine",
+      "operatingsystemrelease": ["3.9"]
     },
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2008 R2",
         "Server 2012 R2",
         "Server 2016",
         "Server 2019"

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "5.x"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?
- Largely removes `cert_file` from README until it can be added back in the solution to #147 and #156 
- Bumps version in preparation for next tag

### What ticket does this PR close?
Connected to #163

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation