### PR TITLE
66 Remove out Conjur EE v4 support from code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Support for using the Conjur Puppet module with Conjur Enterprise v4 is removed
+  [cyberark/conjur-puppet#66](https://github.com/cyberark/conjur-puppet/issues/20).
+
 ## [2.0.5] - 2020-07-28
 
 ### Added

--- a/lib/facter/conjur.rb
+++ b/lib/facter/conjur.rb
@@ -35,7 +35,7 @@ Facter.add :conjur do
     end
 
     def version
-      @version ||= config['version'] || 4
+      @version ||= config['version'] || 5
     end
 
     # A common mistake is to omit the trailing slash in an uri.

--- a/lib/puppet/functions/conjur/client.rb
+++ b/lib/puppet/functions/conjur/client.rb
@@ -57,12 +57,8 @@ Puppet::Functions.create_function :'conjur::client' do
       end
 
       def authenticate login, key, account = nil
-        case version
-        when 4
-          account = 'users'
-        when 5
-          raise ArgumentError, "account is required for v5" unless account
-        end
+        raise ArgumentError, "account is required for v5" unless account
+
         post ['authn', account, login, 'authenticate'].
             map(&URI.method(:encode_www_form_component)).join('/'), key
       end
@@ -83,13 +79,10 @@ Puppet::Functions.create_function :'conjur::client' do
       end
 
       def variable_value account, id, token = nil
-        path = case version
-          when 4
-            ['variables', URI.encode_www_form_component(id), 'value']
-          when 5
-            raise ArgumentError, "account is required for v5" unless account
-            ['secrets', account, 'variable', ERB::Util.url_encode(id)]
-               end.join('/')
+        raise ArgumentError, "account is required for v5" unless account
+
+        path = ['secrets', account, 'variable', ERB::Util.url_encode(id)].join('/')
+
         get path, Base64.urlsafe_encode64(token)
       end
 

--- a/spec/functions/conjur_secret_spec.rb
+++ b/spec/functions/conjur_secret_spec.rb
@@ -23,20 +23,6 @@ describe 'conjur::secret', conjur: :mock do
     context "with #{os_family} platform" do
       let(:facts) { { os: { family: os_family } } }
 
-      context "with Conjur v4 API" do
-        before do
-          allow_authorized_conjur_get('/api/variables/key/value') \
-              .and_return http_ok 'variable value'
-          allow_authorized_conjur_get('/api/variables/tls%2Fkey/value') \
-              .and_return http_ok 'tls key value'
-          allow_authorized_conjur_get('/api/variables/var+with+spaces/value') \
-              .and_return http_ok 'var with spaces value'
-          allow_authorized_conjur_get('/api/variables/bad%2Ftls%2Fkey/value') \
-              .and_return http_unauthorized
-        end
-        include_examples "fetching secrets"
-      end
-
       context "with Conjur v5 API" do
         let(:facts) {{ conjur_version: 5, os: { family: os_family } }}
         before do

--- a/spec/functions/conjur_token_spec.rb
+++ b/spec/functions/conjur_token_spec.rb
@@ -4,7 +4,7 @@ describe 'conjur::token', conjur: :mock do
   ['Windows', 'RedHat'].each do |os_family|
     context "with #{os_family} platform" do
       let(:facts) { { os: { family: os_family } } }
-      
+
       it "calls out to client" do
         client = { 'uri' => 'foo', 'version' => 5, 'cert' => 'foo' }
         client.define_singleton_method(:freeze) {} # to avoid rspec warnings

--- a/spec/unit/puppet_client_spec.rb
+++ b/spec/unit/puppet_client_spec.rb
@@ -5,7 +5,7 @@ require 'webrick/https'
 describe 'conjur::client' do
   include RSpec::Puppet::FunctionExampleGroup
   let(:pem) { cert && cert.to_pem }
-  let(:version) { 4 }
+  let(:version) { 5 }
   subject(:client) { find_function.execute uri, version, pem }
 
   ['Windows', 'RedHat'].each do |os_family|
@@ -135,16 +135,6 @@ xCbuhI/IUunMm+F/8gOcAGd9L3j0g5ZOsGSF34NXi21BrlFGQdWFzg==
             end
           end
 
-          context "with Conjur v4 API" do
-            before do
-              allow(conjur_connection).to receive(:post) \
-                  .with('/api/authn/users/alice/authenticate', 'the api key', nil) \
-                  .and_return http_ok 'the token'
-            end
-
-            include_examples "authentication"
-          end
-
           context "with Conjur v5 API" do
             before do
               allow(conjur_connection).to receive(:post) \
@@ -157,19 +147,19 @@ xCbuhI/IUunMm+F/8gOcAGd9L3j0g5ZOsGSF34NXi21BrlFGQdWFzg==
 
       it "correctly encodes username" do
         allow(conjur_connection).to receive(:post) \
-            .with('/api/authn/users/host%2Fpuppettest/authenticate', 'the api key', nil) \
+            .with('/api/authn/test/host%2Fpuppettest/authenticate', 'the api key', nil) \
             .and_return http_ok 'the host token'
 
-        expect(subject.authenticate 'host/puppettest', 'the api key') \
+        expect(subject.authenticate 'host/puppettest', 'the api key', 'test') \
             .to eq 'the host token'
         end
 
         it "raises error when server errors" do
           allow(conjur_connection).to receive(:post) \
-              .with('/api/authn/users/alice/authenticate', 'the api key', nil) \
+              .with('/api/authn/test/alice/authenticate', 'the api key', nil) \
               .and_return http_unauthorized
 
-          expect { subject.authenticate 'alice', 'the api key' } \
+          expect { subject.authenticate 'alice', 'the api key', 'test' } \
               .to raise_error Net::HTTPError
           end
         end


### PR DESCRIPTION
Since Conjur v4 is deprecated we can ssafely remove support for this API
version from the code. In the process, some of the code is simplified,
though we left the "version" variable to be able to forward-support
higher versions of the API.

### What ticket does this PR close?
Connected to #66

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation