### PR TITLE
184 Converted positional params to `conjur::secret` to a hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `conjur::secret` now must be used as a `Deferred` function. Method signature has
   changed as well. [cyberark/conjur-puppet#13](https://github.com/cyberark/conjur-puppet/issues/13).
+- `conjur::secret` Optional parameters now use a Hash instead of positional parameters.
+  [cyberark/conjur-puppet#184](https://github.com/cyberark/conjur-puppet/issues/184).
 
 ### Removed
 - Support for using the Conjur Puppet module with Conjur Enterprise v4 is removed

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -132,16 +132,16 @@ $sslcert = @("EOT")
 -----END CERTIFICATE-----
 |-EOT
 
-$dbpass = Sensitive(Deferred(conjur::secret, ['production/postgres/password',
-  "https://my.conjur.org",
-  "myaccount",
-  "host/myhost",
-  Sensitive("2z9mndg1950gcx1mcrs6w18bwnp028dqkmc34vj8gh2p500ny1qk8n"),
-  $sslcert
-]))
+$dbpass = Sensitive(Deferred(conjur::secret, ['production/postgres/password', {
+  appliance_url => "https://my.conjur.org",
+  account => "myaccount",
+  authn_login => "host/myhost",
+  authn_api_key => Sensitive("2z9mndg1950gcx1mcrs6w18bwnp028dqkmc34vj8gh2p500ny1qk8n"),
+  ssl_certificate => $sslcert
+}]))
 ```
 
-#### `conjur::secret(String $variable_id, Optional[String] $appliance_url, Optional[String] $account, Optional[String] $authn_login, Optional[Sensitive] $authn_api_key, Optional[String] $ssl_certificate, Optional[String] $version)`
+#### `conjur::secret(String $variable_id, Optional[Hash] $options)`
 
 Function to retrieve a Conjur / DAP secret
 
@@ -164,13 +164,13 @@ $sslcert = @("EOT")
 -----END CERTIFICATE-----
 |-EOT
 
-$dbpass = Sensitive(Deferred(conjur::secret, ['production/postgres/password',
-  "https://my.conjur.org",
-  "myaccount",
-  "host/myhost",
-  Sensitive("2z9mndg1950gcx1mcrs6w18bwnp028dqkmc34vj8gh2p500ny1qk8n"),
-  $sslcert
-]))
+$dbpass = Sensitive(Deferred(conjur::secret, ['production/postgres/password', {
+  appliance_url => "https://my.conjur.org",
+  account => "myaccount",
+  authn_login => "host/myhost",
+  authn_api_key => Sensitive("2z9mndg1950gcx1mcrs6w18bwnp028dqkmc34vj8gh2p500ny1qk8n"),
+  ssl_certificate => $sslcert
+}]))
 ```
 
 ##### `variable_id`
@@ -179,39 +179,16 @@ Data type: `String`
 
 Conjur / DAP variable ID that you want the value of.
 
-##### `appliance_url`
+##### `options`
 
-Data type: `Optional[String]`
+Data type: `Optional[Hash]`
 
-The URL of the Conjur or DAP instance..
-
-##### `account`
-
-Data type: `Optional[String]`
-
-Name of the Conjur account that contains this variable.
-
-##### `authn_login`
-
-Data type: `Optional[String]`
-
-The identity you are using to authenticate to the Conjur / DAP instance.
-
-##### `authn_api_key`
-
-Data type: `Optional[Sensitive]`
-
-The API key of the identity you are using to authenticate with.
-
-##### `ssl_certificate`
-
-Data type: `Optional[String]`
-
-The _raw_ PEM-encoded x509 CA certificate chain for the DAP instance.
-
-##### `version`
-
-Data type: `Optional[String]`
-
-Conjur API version, defaults to 5.
+Optional parameter specifying server identity overrides
+The following keys are supported in the options hash:
+- appliance_url: The URL of the Conjur or DAP instance..
+- account: Name of the Conjur account that contains this variable.
+- authn_login: The identity you are using to authenticate to the Conjur / DAP instance.
+- authn_api_key: The API key of the identity you are using to authenticate with.
+- ssl_certificate: The _raw_ PEM-encoded x509 CA certificate chain for the DAP instance.
+- version: Conjur API version, defaults to 5.
 

--- a/examples/puppetmaster/code/environments/production/manifests/site.pp
+++ b/examples/puppetmaster/code/environments/production/manifests/site.pp
@@ -16,13 +16,13 @@ node default {
   # you would use the optional parameters to the `conjur::secret` function as
   # shown below.
   #
-  # $secret = Sensitive(Deferred(conjur::secret, ['inventory/db-password',
-  #   lookup('conjur::appliance_url'),
-  #   lookup('conjur::account'),
-  #   lookup('conjur::authn_login'),
-  #   lookup('conjur::authn_api_key'),
-  #   lookup('conjur::ssl_certificate')
-  # ]))
+  # $secret = Sensitive(Deferred(conjur::secret, ['inventory/db-password', {
+  #   appliance_url => lookup('conjur::appliance_url'),
+  #   account => lookup('conjur::account'),
+  #   authn_login => lookup('conjur::authn_login'),
+  #   authn_api_key => lookup('conjur::authn_api_key'),
+  #   ssl_certificate => lookup('conjur::ssl_certificate')
+  # }]))
 
   notify { "Writing secret to ${pem_file}...": }
   file { $pem_file: ensure => file, content => $secret }

--- a/examples/puppetmaster/test.sh
+++ b/examples/puppetmaster/test.sh
@@ -11,13 +11,6 @@ COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-puppetmaster_$(openssl rand -hex 3)
 
 PUPPET_SERVER_TAG=latest
 PUPPET_AGENT_TAGS=( latest )
-if [ "${1:-}" = "5" ]; then
-  PUPPET_SERVER_TAG="5.3.7"
-  PUPPET_AGENT_TAGS=(
-    "5.5.1"
-    "latest"
-  )
-fi
 export PUPPET_SERVER_TAG
 
 echo "Using Puppet server '$PUPPET_SERVER_TAG' with agents: '${PUPPET_AGENT_TAGS[@]}'"
@@ -254,13 +247,13 @@ $ssl_certificate
   echo "
     node '$hostname' {
       \$pem_file  = '/tmp/test.pem'
-      \$secret = Sensitive(Deferred(conjur::secret, ['inventory/db-password',
-        lookup('conjur::appliance_url'),
-        lookup('conjur::account'),
-        lookup('conjur::authn_login'),
-        lookup('conjur::authn_api_key'),
-        lookup('conjur::ssl_certificate')
-      ]))
+      \$secret = Sensitive(Deferred(conjur::secret, ['inventory/db-password', {
+          appliance_url => lookup('conjur::appliance_url'),
+          account => lookup('conjur::account'),
+          authn_login => lookup('conjur::authn_login'),
+          authn_api_key => lookup('conjur::authn_api_key'),
+          ssl_certificate => lookup('conjur::ssl_certificate')
+      }]))
 
       notify { \"Writing secret to \${pem_file}...\": }
       file { \$pem_file:

--- a/spec/functions/conjur_secret_spec.rb
+++ b/spec/functions/conjur_secret_spec.rb
@@ -33,16 +33,21 @@ describe 'conjur::secret', conjur: :mock do
       end
 
       describe "with all parameters (server-side params)" do
+        let(:full_options) {
+          {
+            'appliance_url' => appliance_url,
+            'account' => account,
+            'authn_login' => authn_login,
+            'authn_api_key' => authn_api_key,
+            'ssl_certificate' => ssl_certificate
+          }
+        }
+
         it "fetches the given variable using token from conjur class" do
           expect(mock_connection).to receive(:post).with(authn_url, authn_api_key.unwrap)
             .and_return(http_ok mock_token)
 
-          actual_value = subject.execute(variable_id,
-                                         appliance_url,
-                                         account,
-                                         authn_login,
-                                         authn_api_key,
-                                         ssl_certificate).unwrap
+          actual_value = subject.execute(variable_id, full_options).unwrap
           expect(actual_value).to eq 'variable value'
         end
 
@@ -51,12 +56,7 @@ describe 'conjur::secret', conjur: :mock do
             .and_return(http_unauthorized)
 
           expect {
-            subject.execute(variable_id,
-                            appliance_url,
-                            account,
-                            authn_login,
-                            authn_api_key,
-                            ssl_certificate) }.to raise_error Net::HTTPError
+            subject.execute(variable_id, full_options) }.to raise_error Net::HTTPError
         end
       end
 


### PR DESCRIPTION
Since positional parameters are both hart to use and consistently get
correct without documentation, this change ensures that we use a hash
instead which will allow better UX and possibly enable use of partial
overrides.

### What ticket does this PR close?
Connected to #184 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation