### PR TITLE
Limit publishing to v2 and master branches only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,10 +110,18 @@ pipeline {
     stage('Release Puppet module') {
       when {
         allOf {
+          // Only publish from mainline and v2 branches
+          anyOf {
+            branch 'master'
+            branch 'v2'
+          }
+
           // Current git HEAD is an annotated tag
           expression {
             sh(returnStatus: true, script: 'git describe --exact | grep -q \'^v[0-9.]\\+$\'') == 0
           }
+
+          // Don't try to publish during daily builds
           not { triggeredBy  'TimerTrigger' }
         }
       }


### PR DESCRIPTION
This will make sure that publishing of tags only occurs when the source
branch is either `v2` or `master` as we should not have any other
sources of publishable artifacts.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation