### PR TITLE
Revert "Limit publishing to v2 and master branches only"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,18 +110,10 @@ pipeline {
     stage('Release Puppet module') {
       when {
         allOf {
-          // Only publish from mainline and v2 branches
-          anyOf {
-            branch 'master'
-            branch 'v2'
-          }
-
           // Current git HEAD is an annotated tag
           expression {
             sh(returnStatus: true, script: 'git describe --exact | grep -q \'^v[0-9.]\\+$\'') == 0
           }
-
-          // Don't try to publish during daily builds
           not { triggeredBy  'TimerTrigger' }
         }
       }


### PR DESCRIPTION
This reverts commit 75aa90ad32a5474e1f9df39fb1e6edd518dcf4fc.

Since tags are built in separate builds with no parent branch, this
change did not work as expected. As such, it will need to be reverted
until we find a better way to lock down the tag's parent branch.

### What ticket does this PR close?

N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation