### PR TITLE
194 Add code coverage metrics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 Gemfile.lock
 
-pkg/
-examples/
+/coverage/
+/pkg/
+/examples/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 Gemfile.lock
 
+/.cache/
+/.config/
 /coverage/
 /pkg/
 /examples/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,10 @@
 .yardwarns
 *.iml
 /.bundle/
+/.cache/
+/.config/
 /.idea/
+/.pdk/
 /.rvmrc*
 /.vagrant/
 /conjur.conf

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development do
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem 'simplecov-cobertura',                                     require: false
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
           post {
             always {
               junit 'spec/output/rspec.xml'
+              cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'coverage/coverage.xml', conditionalCoverageTargets: '100, 0, 0', failUnhealthy: true, failUnstable: false, lineCoverageTargets: '97, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '100, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
               archiveArtifacts artifacts: 'spec/output/rspec.xml', fingerprint: true
             }
           }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 SimpleCov.start
 
 # Ensure that RSpec is set as mocking framework before anything else
-# as the `require` statemens throw warnings otherwise
+# as the `require` statements throw warnings otherwise
 RSpec.configure do |c|
   c.mock_with :rspec
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+# Ensure that SimpleCov loads before anything else
+require 'simplecov'
+require 'simplecov-cobertura'
+
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+SimpleCov.start
+
+# Ensure that RSpec is set as mocking framework before anything else
+# as the `require` statemens throw warnings otherwise
 RSpec.configure do |c|
   c.mock_with :rspec
 end


### PR DESCRIPTION
### What does this PR do?
- Adds code coverage metrics to Jenkins
- Pins current coverage metrics as minimums for code coverage

See https://jenkins.conjur.net/job/cyberark--conjur-puppet/job/194-add-code-coverage-metrics/ for output

### What ticket does this PR close?
Connected to #194 
Connected to #121 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation