### PR TITLE
E2E tests install the packaged module by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,11 @@ docker build -t puppet-pdk -f Dockerfile.pdk .
 docker run --rm \
   -v $PWD:/conjur -w /conjur \
   puppet-pdk \
-  bash -ec 'pdk build --force'
+  bash -ec "
+    pdk build --force
+
+    # Ensure there's a generically named copy of the packaged module. This will allow the
+    # packaged module to be more easily referenced in any automation scripts e.g. integration
+    # tests.
+    cp ./pkg/cyberark-conjur-*.tar.gz ./pkg/cyberark-conjur.tar.gz;
+  "

--- a/examples/puppetmaster/docker-compose.yml
+++ b/examples/puppetmaster/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       - 8140
     volumes:
       - ./code:/etc/puppetlabs/code/
-      - ../../.:/etc/puppetlabs/code/environments/production/modules/conjur
+      # The mounted onto path '/conjur' is a proxy location that allows us to decide, at
+      # runtime, between installing the packaged module or using the module source.
+      - ../../.:/conjur
     # In some environments puppetdb host gets cert for puppetdb.local.
     # Make sure the connection works either way.
     environment:


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

The envvar INSTALL_PACKAGED_MODULE has been added to the E2E tests and allows developers to toggle between installing a packaged module or using the module source. The default (which is used by CI) is to install the packaged module.

- _How should the reviewer approach this PR, especially if manual tests are required?_

N/A

- _Are there relevant screenshots you can add to the PR description?_

N/A

### What ticket does this PR close?
Connected to #173  

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation