### PR TITLE
79 Add integration test for use of special chars in variable ID

### DIFF
--- a/examples/puppetmaster/policy.yml
+++ b/examples/puppetmaster/policy.yml
@@ -4,6 +4,7 @@
     description: Policy that governs access to the inventory database
   body:
     - !variable &db-password db-password
+    - !variable &funky-variable funky/special @#$%^&*(){}[].,+/variable
 
     - !layer
     - !host-factory
@@ -12,6 +13,11 @@
     - !permit
       role: [ !layer ]
       resource: *db-password
+      privilege: [ read, execute ]
+
+    - !permit
+      role: [ !layer ]
+      resource: *funky-variable
       privilege: [ read, execute ]
 
     - !host &h_agent_apikey

--- a/examples/puppetmaster/test.sh
+++ b/examples/puppetmaster/test.sh
@@ -123,7 +123,7 @@ get_hf_token() {
 symlink_conjur_module() {
   echo "Creating a symlink of cyberark-conjur module source on server..."
   run_in_puppet bash -c "
-    ln -s /conjur /etc/puppetlabs/code/environments/production/modules/conjur
+    ln -fs /conjur /etc/puppetlabs/code/environments/production/modules/conjur
   "
 }
 

--- a/examples/puppetmaster/vagrant/5_get_puppet_artifacts.sh
+++ b/examples/puppetmaster/vagrant/5_get_puppet_artifacts.sh
@@ -4,5 +4,8 @@
 
 set -eou pipefail
 
-echo "Getting C:\tmp\test.pem from Windows VM"
-vagrant powershell -c "cat \tmp\test.pem"
+echo 'Getting C:\tmp\creds1.txt from Windows VM'
+vagrant powershell -c 'cat \tmp\creds1.txt'
+
+echo 'Getting C:\tmp\creds2.txt from Windows VM'
+vagrant powershell -c 'cat \tmp\creds2.txt'


### PR DESCRIPTION
While we have a few unit tests around this, having a solid integration
test for odd characters in the ID will ensure that we do not get odd
behaviour when interacting with a rela Conjur server.

### What does this PR do?
- Makes Linux and Windows integration testing also use a variable with special characters in ID

### What ticket does this PR close?
Connected to #79 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation