### PR TITLE
Integration test against Windows environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
       }
     }
 
-    // workaround for Jenkins not fetching tags
+    // Workaround for Jenkins not fetching tags
     stage('Fetch tags') {
       steps {
         withCredentials(
@@ -50,10 +50,9 @@ pipeline {
       }
     }
 
-
     stage('Tests') {
       parallel {
-        stage('Prepare Windows 2016 with containers') {
+        stage('Setup Win2016') {
           agent { label 'executor-windows-2016-containers' }
           stages {
             stage('Configure Windows Node'){
@@ -80,7 +79,7 @@ pipeline {
           }
         }
 
-        stage('With Windows 2016 containers') {
+        stage('Test Win2016') {
           stages {
             stage("Wait for Windows node") {
               steps {
@@ -100,8 +99,7 @@ pipeline {
               }
             }
 
-// Integration tests
-            stage('E2E - Puppet 6 - Conjur 5') {
+            stage('Puppet 6 & Conjur 5 Integration Tests') {
               steps {
                 dir('examples/puppetmaster') {
                   sh '''
@@ -125,8 +123,7 @@ pipeline {
           }
         }
 
-// Linting and unit tests
-        stage('Linting and unit tests') {
+        stage('Linting & Unit Tests') {
           steps {
             sh './test.sh'
           }

--- a/examples/puppetmaster/windows-agent.Dockerfile
+++ b/examples/puppetmaster/windows-agent.Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/windows/servercore:1607
+
+RUN powershell mkdir "c:\tmp"
+
+RUN powershell \
+  wget https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-x64-latest.msi \
+    -outfile puppet6.msi
+
+RUN powershell Start-Process msiexec.exe \
+   -Wait \
+   -ArgumentList \
+    '/qn /quiet /norestart /L*v C:\puppet_install_log.txt /i C:\puppet6.msi PUPPET_AGENT_STARTUP_MODE=Manual'

--- a/expose-daemon.ps1
+++ b/expose-daemon.ps1
@@ -1,0 +1,149 @@
+$ErrorActionPreference = 'Stop';
+
+if (!(Test-Path $env:USERPROFILE\.docker)) {
+  mkdir $env:USERPROFILE\.docker
+}
+
+$ipAddresses = ((Get-NetIPAddress -AddressFamily IPv4).IPAddress) -Join ','
+
+function ensureDirs($dirs) {
+  foreach ($dir in $dirs) {
+    if (!(Test-Path $dir)) {
+      mkdir $dir
+    }
+  }
+}
+
+# https://docs.docker.com/engine/security/https/
+# Thanks to @artisticcheese! https://artisticcheese.wordpress.com/2017/06/10/using-pure-powershell-to-generate-tls-certificates-for-docker-daemon-running-on-windows/
+function createCA($serverCertsPath) {
+  Write-Host "`n=== Generating CA"
+  $parms = @{
+    type = "Custom" ;
+    KeyExportPolicy = "Exportable";
+    Subject = "CN=Docker TLS Root";
+    CertStoreLocation = "Cert:\LocalMachine\My";
+    HashAlgorithm = "sha256";
+    KeyLength = 4096;
+    KeyUsage = @("CertSign", "CRLSign");
+    TextExtension = @("2.5.29.19 ={critical} {text}ca=1")
+  }
+  $rootCert = New-SelfSignedCertificate @parms
+
+  Write-Host "`n=== Generating CA public key"
+  $parms = @{
+    Path = "$serverCertsPath\ca.pem";
+    Value = "-----BEGIN CERTIFICATE-----`n" `
+          + [System.Convert]::ToBase64String($rootCert.RawData, [System.Base64FormattingOptions]::InsertLineBreaks) `
+          + "`n-----END CERTIFICATE-----";
+    Encoding = "ASCII";
+  }
+  Set-Content @parms
+  return $rootCert
+}
+
+# https://docs.docker.com/engine/security/https/
+function createCerts($rootCert, $serverCertsPath, $serverName, $ipAddresses, $clientCertsPath) {
+  Write-Host "`n=== Generating Server certificate"
+  $parms = @{
+    CertStoreLocation = "Cert:\LocalMachine\My";
+    Signer = $rootCert;
+    Subject = "CN=serverCert";
+    KeyExportPolicy = "Exportable";
+    Provider = "Microsoft Enhanced Cryptographic Provider v1.0";
+    Type = "SSLServerAuthentication";
+    HashAlgorithm = "sha256";
+    TextExtension = @("2.5.29.37= {text}1.3.6.1.5.5.7.3.1", "2.5.29.17={text}DNS=$serverName&DNS=localhost&IPAddress=$($ipAddresses.Split(',') -Join '&IPAddress=')");
+    KeyLength = 4096;
+  }
+  $serverCert = New-SelfSignedCertificate @parms
+
+  $parms = @{
+    Path = "$serverCertsPath\server-cert.pem";
+    Value = "-----BEGIN CERTIFICATE-----`n" `
+          + [System.Convert]::ToBase64String($serverCert.RawData, [System.Base64FormattingOptions]::InsertLineBreaks) `
+          + "`n-----END CERTIFICATE-----";
+    Encoding = "Ascii"
+  }
+  Set-Content @parms
+
+  Write-Host "`n=== Generating Server private key"
+  $privateKeyFromCert = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($serverCert)
+  $parms = @{
+    Path = "$serverCertsPath\server-key.pem";
+    Value = ("-----BEGIN PRIVATE KEY-----`n" `
+          + [System.Convert]::ToBase64String($privateKeyFromCert.Key.Export([System.Security.Cryptography.CngKeyBlobFormat]::Pkcs8PrivateBlob), [System.Base64FormattingOptions]::InsertLineBreaks) `
+          + "`n-----END PRIVATE KEY-----");
+    Encoding = "Ascii";
+  }
+  Set-Content @parms
+
+  Write-Host "`n=== Generating Client certificate"
+  $parms = @{
+    CertStoreLocation = "Cert:\LocalMachine\My";
+    Subject = "CN=clientCert";
+    Signer = $rootCert ;
+    KeyExportPolicy = "Exportable";
+    Provider = "Microsoft Enhanced Cryptographic Provider v1.0";
+    TextExtension = @("2.5.29.37= {text}1.3.6.1.5.5.7.3.2") ;
+    HashAlgorithm = "sha256";
+    KeyLength = 4096;
+  }
+  $clientCert = New-SelfSignedCertificate  @parms
+
+  $parms = @{
+    Path = "$clientCertsPath\cert.pem" ;
+    Value = ("-----BEGIN CERTIFICATE-----`n" + [System.Convert]::ToBase64String($clientCert.RawData, [System.Base64FormattingOptions]::InsertLineBreaks) + "`n-----END CERTIFICATE-----");
+    Encoding = "Ascii";
+  }
+  Set-Content @parms
+
+  Write-Host "`n=== Generating Client key"
+  $clientprivateKeyFromCert = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($clientCert)
+  $parms = @{
+    Path = "$clientCertsPath\key.pem";
+    Value = ("-----BEGIN PRIVATE KEY-----`n" `
+          + [System.Convert]::ToBase64String($clientprivateKeyFromCert.Key.Export([System.Security.Cryptography.CngKeyBlobFormat]::Pkcs8PrivateBlob), [System.Base64FormattingOptions]::InsertLineBreaks) `
+          + "`n-----END PRIVATE KEY-----");
+    Encoding = "Ascii";
+  }
+  Set-Content @parms
+
+  copy $serverCertsPath\ca.pem $clientCertsPath\ca.pem
+}
+
+function updateConfig($daemonJson, $serverCertsPath) {
+  $config = @{}
+  if (Test-Path $daemonJson) {
+    $config = (Get-Content $daemonJson) -join "`n" | ConvertFrom-Json
+  }
+
+  $config = $config | Add-Member(@{ `
+    hosts = @("tcp://0.0.0.0:2376", "npipe://"); `
+    tlsverify = $true; `
+    tlscacert = "$serverCertsPath\ca.pem"; `
+    tlscert = "$serverCertsPath\server-cert.pem"; `
+    tlskey = "$serverCertsPath\server-key.pem" `
+    }) -Force -PassThru
+
+  Write-Host "`n=== Creating / Updating $daemonJson"
+  $config | ConvertTo-Json | Set-Content $daemonJson -Encoding Ascii
+}
+
+$dockerData = "$env:ProgramData\docker"
+$userPath = "$env:USERPROFILE\.docker"
+
+ensureDirs @("$dockerData\certs.d", "$dockerData\config", "$userPath")
+
+$serverCertsPath = "$dockerData\certs.d"
+$clientCertsPath = "$userPath"
+$rootCert = createCA "$dockerData\certs.d"
+
+createCerts $rootCert $serverCertsPath $serverName $ipAddresses $clientCertsPath
+updateConfig "$dockerData\config\daemon.json" $serverCertsPath $enableLCOW $experimental
+
+Write-Host "Restarting Docker"
+Restart-Service docker
+
+Write-Host "Opening Docker TLS port"
+& netsh advfirewall firewall add rule name="Docker TLS" dir=in action=allow protocol=TCP localport=2376


### PR DESCRIPTION
+ Add ability to integration tests against Windows environment
   Integration testing against puppet agents running on Windows is possible and configurable. Export the WINDOWS_DOCKER_HOST envvar to enable the Windows tests. The configurable options are available as envvars WINDOWS_DOCKER_HOST, WINDOWS_DOCKER_CERT_PATH, WINDOWS_DOCKER_TLS_VERIFY, MAIN_HOST_IP. MAIN_HOST_IP is the IP address of the host where the tests are running that should be accessible from containers running in the Windows Docker Daemon.
+ Add Windows node to integration tests in Jenkins
   Adds a Windows 2016, with containers, node to the pipeline using the parallel stages approach for cooperation between Jenkins nodes. This provides a Windows Docker daemon for the integration tests to use

Here's an example of a run where the Windows environment is available https://asciinema.org/a/4QANgWX4IEgU6vOx9Za8TdlAl.

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation