### PR TITLE
Made Jenkinsfile release step match on pre-release tags too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,14 +73,9 @@ pipeline {
     }
 
     stage('Release Puppet module') {
+      // Only run this stage when triggered by a tag
       when {
-        allOf {
-          // Current git HEAD is an annotated tag
-          expression {
-            sh(returnStatus: true, script: 'git describe --exact | grep -q \'^v[0-9.]\\+$\'') == 0
-          }
-          not { triggeredBy  'TimerTrigger' }
-        }
+        tag "v*"
       }
       steps {
         sh './release.sh'


### PR DESCRIPTION
Old version of the logic was only capable of handling `vxx.yy.zz` tag
pattern. This change makes it so that we can also push pre-release
semver tags too.

### What does this PR do?
- Allows publishing from pre-release tags

### What ticket does this PR close?
Connected to #199 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation