### PR TITLE
Disable PDK analytics

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,10 @@ pipeline {
     cron(getDailyCronString())
   }
 
+  environment {
+    PDK_DISABLE_ANALYTICS = 'true'
+  }
+
   stages {
     stage('Validate') {
       parallel {

--- a/release.sh
+++ b/release.sh
@@ -9,5 +9,7 @@ summon docker run --rm -t \
   --env-file @SUMMONENVFILE \
   puppet-pdk \
   bash -ec """
-    pdk release --skip-documentation --skip-changelog --force
+    PDK_DISABLE_ANALYTICS=true pdk release --skip-documentation \
+                                           --skip-changelog \
+                                           --force
   """


### PR DESCRIPTION
This change ensures that we do not consent to collection of analytics
and that we also skip this question during the release of our puppet
module.

### What does this PR do?
- Use of PDK analytics has been disabled

### What ticket does this PR close?
Connected to #199 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation