### PR TITLE
Use PuppetForge API key to publish the release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,5 +11,6 @@ summon docker run --rm -t \
   bash -ec """
     PDK_DISABLE_ANALYTICS=true pdk release --skip-documentation \
                                            --skip-changelog \
+                                           --forge-token='$PDK_FORGE_TOKEN' \
                                            --force
   """

--- a/secrets.yml
+++ b/secrets.yml
@@ -1,3 +1,1 @@
-BLACKSMITH_FORGE_URL: 'https://forgeapi.puppetlabs.com'
-BLACKSMITH_FORGE_USERNAME: !var prod/puppet-forge/cyberark/username
-BLACKSMITH_FORGE_PASSWORD: !var prod/puppet-forge/cyberark/password
+PDK_FORGE_TOKEN: !var prod/puppet-forge/cyberark/api-key


### PR DESCRIPTION
Since PDK only uses the API key and not the user/pass combo, we now have
to use this new credential in our release script.

~Blocked by https://github.com/conjurinc/conjurops-policies/pull/139~

### What ticket does this PR close?
Connected to #199 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation