### PR TITLE
Ignore `.pdk` directory when building artifacts

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -6,6 +6,7 @@
 *.iml
 /.bundle/
 /.idea/
+/.pdk/
 /.vagrant/
 /coverage/
 /bin/


### PR DESCRIPTION
Since PDK may use this directory for caching, we don't want its content
to polute our artifacts so it has been added to `.pdkignore`.

### What ticket does this PR close?
Connected to #199 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation