### PR TITLE
Fixed escaping of PDK token during releases

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,6 +11,6 @@ summon docker run --rm -t \
   bash -ec """
     PDK_DISABLE_ANALYTICS=true pdk release --skip-documentation \
                                            --skip-changelog \
-                                           --forge-token='$PDK_FORGE_TOKEN' \
+                                           --forge-token="\$PDK_FORGE_TOKEN" \
                                            --force
   """


### PR DESCRIPTION
Due to the way the shell scriptis used, we needed to escape the variable
name for it to be interpreted within the container itself.

### What ticket does this PR close?
Connected to #199

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation