### PR TITLE
Exclude unnecessary files from release artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.DS_Store
+cc-test-reporter
 Gemfile.lock
 
 /.cache/

--- a/.pdkignore
+++ b/.pdkignore
@@ -35,6 +35,7 @@
 /.pdkignore
 /Rakefile
 /rakelib/
+/.cache
 /.rspec
 /.rubocop.yml
 /.travis.yml
@@ -53,4 +54,5 @@ tmp/
 /conjur.conf
 /conjur.pem
 /rspec.xml
+cc-test-reporter
 puppet_install_log.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Release artifact excludes files that may be inadvertently added to the archive
+  during builds.
+  [cyberark/conjur-puppet#213](https://github.com/cyberark/conjur-puppet/issues/213)
+
 ## [3.0.0-rc2] - 2020-08-26
 
 ### Added


### PR DESCRIPTION
`cc-test-reporter`, `.cache`, and `.DS_Store` are inadvertently included
into our build artifacts by Jenkins and local builds, bulking up the artifact
size significantly. This change ensures that these files are excluded.

### What ticket does this PR close?
Connected to #213 
### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation