### PR TITLE
Heavily document `Sensitive` and `Deferred` requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Changed recommended usages to no longer wrap the whole invocation in Sensitive as
+  it is generally not needed.
+  [cyberark/conjur-puppet#198](https://github.com/cyberark/conjur-puppet/issues/198)
+
 ## [3.0.0-rc3] - 2020-09-11
 
 ### Fixed

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -64,7 +64,7 @@ Function to retrieve a Conjur / DAP secret
 ##### Agent-based identity invocation
 
 ```puppet
-Sensitive(Deferred(conjur::secret, ['production/postgres/password']))
+Deferred(conjur::secret, ['production/postgres/password'])
 ```
 
 ##### Server-based identity invocation
@@ -76,13 +76,13 @@ $sslcert = @("EOT")
 -----END CERTIFICATE-----
 |-EOT
 
-$dbpass = Sensitive(Deferred(conjur::secret, ['production/postgres/password', {
+$dbpass = Deferred(conjur::secret, ['production/postgres/password', {
   appliance_url => "https://my.conjur.org",
   account => "myaccount",
   authn_login => "host/myhost",
   authn_api_key => Sensitive("2z9mndg1950gcx1mcrs6w18bwnp028dqkmc34vj8gh2p500ny1qk8n"),
   ssl_certificate => $sslcert
-}]))
+}])
 ```
 
 #### `conjur::secret(String $variable_id, Optional[Hash] $options)`
@@ -96,7 +96,7 @@ Returns: `Sensitive` Value of the Conjur variable.
 ###### Agent-based identity invocation
 
 ```puppet
-Sensitive(Deferred(conjur::secret, ['production/postgres/password']))
+Deferred(conjur::secret, ['production/postgres/password'])
 ```
 
 ###### Server-based identity invocation
@@ -108,13 +108,13 @@ $sslcert = @("EOT")
 -----END CERTIFICATE-----
 |-EOT
 
-$dbpass = Sensitive(Deferred(conjur::secret, ['production/postgres/password', {
+$dbpass = Deferred(conjur::secret, ['production/postgres/password', {
   appliance_url => "https://my.conjur.org",
   account => "myaccount",
   authn_login => "host/myhost",
   authn_api_key => Sensitive("2z9mndg1950gcx1mcrs6w18bwnp028dqkmc34vj8gh2p500ny1qk8n"),
   ssl_certificate => $sslcert
-}]))
+}])
 ```
 
 ##### `variable_id`
@@ -132,7 +132,7 @@ The following keys are supported in the options hash:
 - appliance_url: The URL of the Conjur or DAP instance..
 - account: Name of the Conjur account that contains this variable.
 - authn_login: The identity you are using to authenticate to the Conjur / DAP instance.
-- authn_api_key: The API key of the identity you are using to authenticate with.
+- authn_api_key: The API key of the identity you are using to authenticate with (must be Sensitive type).
 - ssl_certificate: The _raw_ PEM-encoded x509 CA certificate chain for the DAP instance.
 - version: Conjur API version, defaults to 5.
 

--- a/lib/puppet/functions/conjur/secret.rb
+++ b/lib/puppet/functions/conjur/secret.rb
@@ -12,12 +12,12 @@ Puppet::Functions.create_function :'conjur::secret' do
   #   - appliance_url: The URL of the Conjur or DAP instance..
   #   - account: Name of the Conjur account that contains this variable.
   #   - authn_login: The identity you are using to authenticate to the Conjur / DAP instance.
-  #   - authn_api_key: The API key of the identity you are using to authenticate with.
+  #   - authn_api_key: The API key of the identity you are using to authenticate with (must be Sensitive type).
   #   - ssl_certificate: The _raw_ PEM-encoded x509 CA certificate chain for the DAP instance.
   #   - version: Conjur API version, defaults to 5.
   # @return [Sensitive] Value of the Conjur variable.
   # @example Agent-based identity invocation
-  #   Sensitive(Deferred(conjur::secret, ['production/postgres/password']))
+  #   Deferred(conjur::secret, ['production/postgres/password'])
   # @example Server-based identity invocation
   #   $sslcert = @("EOT")
   #   -----BEGIN CERTIFICATE-----
@@ -25,13 +25,13 @@ Puppet::Functions.create_function :'conjur::secret' do
   #   -----END CERTIFICATE-----
   #   |-EOT
   #
-  #   $dbpass = Sensitive(Deferred(conjur::secret, ['production/postgres/password', {
+  #   $dbpass = Deferred(conjur::secret, ['production/postgres/password', {
   #     appliance_url => "https://my.conjur.org",
   #     account => "myaccount",
   #     authn_login => "host/myhost",
   #     authn_api_key => Sensitive("2z9mndg1950gcx1mcrs6w18bwnp028dqkmc34vj8gh2p500ny1qk8n"),
   #     ssl_certificate => $sslcert
-  #   }]))
+  #   }])
   dispatch :with_credentials do
     required_param 'String', :variable_id
     optional_param 'Hash', :options


### PR DESCRIPTION
Old documentation did not go into necessary depths to ensure that the
user was provided with all the necessary information about how the
`Deferred` and `Sensitive` chaining work and why they are critical in
ensuring secure use of credentials. This PR ensures that we do that and
fixes some outdated examples.

### What ticket does this PR close?
Connected to #198 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation