### PR TITLE
Fix unknown function error for running examples/puppetmaster locally

### DIFF
--- a/examples/puppetmaster/test.sh
+++ b/examples/puppetmaster/test.sh
@@ -122,8 +122,12 @@ get_hf_token() {
 
 symlink_conjur_module() {
   echo "Creating a symlink of cyberark-conjur module source on server..."
+  local modules_dir="/etc/puppetlabs/code/environments/production/modules"
+  local target="$modules_dir/conjur"
   run_in_puppet bash -c "
-    ln -fs /conjur /etc/puppetlabs/code/environments/production/modules/conjur
+    rm -rf "$target"; \
+    mkdir -p "$modules_dir"; \
+    ln -fs /conjur "$target"
   "
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR adds a fix for the following error:
```
Error: Failed to apply catalog: Unknown function 'conjur::secret'
```
that is seen when running the examples/puppetmaster/test.sh locally.

### What does this PR do?
- Makes sure that the Conjur modules directory that is the target of a
   symlink is cleared before doing the symlink. Without this change,
   the symlink was creating a nested conjur target (...conjur/conjur).
- Makes sure the parent `module` directory exists for the symlink
   target.


### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation