### PR TITLE
Finish support for `cert_file` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Module now fully supports the use of `cert_file` parameter, which accepts the path to the PEM-encoded
+  x509 CA certificate chain for Conjur. Users can supply the module with certificate path in `cert_file` OR
+  with certificate contents in `ssl_certificate`.
+  [cyberark/conjur-puppet#105](https://github.com/cyberark/conjur-puppet/issues/105)
+
 ## [3.0.0] - 2020-09-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -377,9 +377,25 @@ account: myorg
 plugins: []
 appliance_url: https://conjur.mycompany.com
 cert_file: "/absolute/path/to/conjur-ca.pem" # Read from the Puppet agent
+# Alternative for providing the SSL cert
+# ssl_certificate: |
+#  -----BEGIN CERTIFICATE-----
+#  ...
+#  -----END CERTIFICATE-----
 ```
 
-and a `conjur.identity` file that contains:
+| Value Name | Description |
+|-|-|
+| `account` | `Conjur account specified during Conjur setup. |
+| `appliance_url` | `Conjur API endpoint. |
+| `cert_file` | `Path to a file containing the public Conjur SSL cert on the agent. This value **must** be an absolute path and not a relative one. |
+| `ssl_certificate` | `Raw public Conjur SSL cert. Overwritten by the contents read from `cert_file` when it is present. |
+| `version` | Conjur API version. Defaults to `5`. |
+
+Note: **use either `SslCertificate` _or_ `CertFile` but not both as `cert_file`
+overrides the value of `ssl_certificate` setting.**
+
+You will also need a `conjur.identity` file that contains:
 ```netrc
 machine conjur.mycompany.com
     login host/redis001
@@ -392,8 +408,8 @@ _**NOTE: The `conjur.conf` and `conjur.identity` files contain sensitive
   disallow any access to these files by unauthorized (non-root) users
   on a Linux Puppet agent node.**_
 
-The Conjur Puppet Module automatically checks for these files on your node and uses them if they
-are available.
+The Conjur Puppet Module automatically checks for these files on your node and uses
+them if they are available.
 
 To then fetch your credential, you would use the default form of `conjur::secret`:
 ```puppet
@@ -415,7 +431,8 @@ values available to set are:
 |-|-|-|
 | `Account` | `REG_SZ` | Conjur account specified during Conjur setup. |
 | `ApplianceUrl` | `REG_SZ` | Conjur API endpoint. |
-| `SslCertificate` | `REG_SZ` | Raw public Conjur SSL cert.|
+| `CertFile` | `REG_SZ` | Path to a file containing the public Conjur SSL cert on the agent. This value **must** be an absolute path and not a relative one. |
+| `SslCertificate` | `REG_SZ` | Raw public Conjur SSL cert. Overwritten by the contents read from `CertFile` when it is present. |
 | `Version` | `REG_DWORD` | Conjur API version. Defaults to `5`. |
 
 These may be set using Powershell:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -133,6 +133,7 @@ The following keys are supported in the options hash:
 - account: Name of the Conjur account that contains this variable.
 - authn_login: The identity you are using to authenticate to the Conjur / DAP instance.
 - authn_api_key: The API key of the identity you are using to authenticate with (must be Sensitive type).
-- ssl_certificate: The _raw_ PEM-encoded x509 CA certificate chain for the DAP instance.
+- cert_file: The absolute path to CA certificate chain for the DAP instance on the agent. This variable overrides `ssl_certificate`.
+- ssl_certificate: The _raw_ PEM-encoded x509 CA certificate chain for the DAP instance. Overwritten by the contents read from `cert_file` when it is present.
 - version: Conjur API version, defaults to 5.
 

--- a/lib/conjur/puppet_module/config.rb
+++ b/lib/conjur/puppet_module/config.rb
@@ -13,15 +13,18 @@ module Conjur
           Puppet.features.microsoft_windows? ? from_registry : from_file
         end
 
+        def load_cert_file(path)
+          raise "Cert file '#{path}' cannot be found!" unless File.file?(path)
+          File.read path
+        end
+
         def from_file
           return {} unless File.file?(CONFIG_FILE_PATH)
 
           c = YAML.safe_load(File.read(CONFIG_FILE_PATH))
 
           if c['cert_file']
-            raise "Cert file '#{c['cert_file']}' cannot be found!" unless File.file?(c['cert_file'])
-
-            c['ssl_certificate'] ||= File.read c['cert_file']
+            c['ssl_certificate'] = load_cert_file(c['cert_file'])
           end
 
           c
@@ -53,7 +56,9 @@ module Conjur
                           'expected behavior.'
           end
 
-          c['ssl_certificate'] ||= File.read c['cert_file'] if c['cert_file']
+          if c['cert_file']
+            c['ssl_certificate'] = load_cert_file(c['cert_file'])
+          end
 
           c
         end


### PR DESCRIPTION
While support for this parameter was partially in the codebase, the
documentation was lacking and we didn't have good unit tests around
this. This change ensures that we have this capability tested and
documented just as much as the other features.

### What ticket does this PR close?
Connected to #105

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation