### PR TITLE
Fix problems with using `puppet strings` on the codebase

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,10 @@ pipeline {
         stage('Changelog') {
           steps { sh './parse-changelog.sh' }
         }
+
+        stage('Docs') {
+          steps { sh './gen-docs.sh' }
+        }
       }
     }
 

--- a/gen-docs.sh
+++ b/gen-docs.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 strings_cmd="gem install puppet-strings && puppet strings generate --format markdown --out REFERENCE.md"
 
-docker run -it \
+docker run -t \
            -v "$(pwd):/conjur" \
            -w /conjur \
            --entrypoint /bin/bash \

--- a/lib/puppet/type/credential.rb
+++ b/lib/puppet/type/credential.rb
@@ -4,11 +4,11 @@ require 'puppet/type'
 
 # Manages Credential Manager credentials on Windows systems.
 Puppet::Type.newtype(:credential) do
-  desc 'Manages Credential Manager credentials on Windows systems.'
+  @doc = 'Manages Credential Manager credentials on Windows systems.'
 
   ensurable
 
-  newparam(target, namevar: true) do
+  newparam(:target, namevar: true) do
     desc 'Conjur / DAP URL'
   end
 


### PR DESCRIPTION
Old code wasn't using the exact specification for custom types and would
thus fail to generate the documentation. The change just makes sure that
we use the proper construct which makes the process correctly generate
the reference documentation.

### What ticket does this PR close?
Connected to #166

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation