### PR TITLE
Raise better error when authn_api_key is not wrapped in `Sensitive()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   with certificate contents in `ssl_certificate`.
   [cyberark/conjur-puppet#105](https://github.com/cyberark/conjur-puppet/issues/105)
 
+### Changed
+- If `authn_api_key` is not wrapped in `Sensitive` class, we now raise a descriptive
+  error as to why we cannot proceed.
+  [cyberark/conjur-puppet#232](https://github.com/cyberark/conjur-puppet/issues/232)
+
 ## [3.0.0] - 2020-09-17
 
 ### Added

--- a/lib/puppet/functions/conjur/secret.rb
+++ b/lib/puppet/functions/conjur/secret.rb
@@ -77,6 +77,11 @@ Puppet::Functions.create_function :'conjur::secret' do
     # we will be modifying it
     opts = options.dup
 
+    if opts['authn_api_key']
+      raise "Value of 'authn_api_key' must be wrapped in 'Sensitive()'!" \
+        unless opts['authn_api_key'].is_a? Puppet::Pops::Types::PSensitiveType::Sensitive
+    end
+
     opts['version'] ||= 5
 
     # If we didn't get any config from the server, assume it's on the agent

--- a/spec/functions/conjur_secret_spec.rb
+++ b/spec/functions/conjur_secret_spec.rb
@@ -73,6 +73,15 @@ describe 'conjur::secret', conjur: :mock do
       end
 
       describe 'using all parameters (server-side params)' do
+        it 'raises error if authn_api_key is not Sensitive type' do
+          options = {
+            'authn_api_key' => 'just a string',
+          }
+
+          expect { subject.execute(variable_id, options) }.to raise_error \
+            'Value of \'authn_api_key\' must be wrapped in \'Sensitive()\'!'
+        end
+
         describe 'with ssl_certificate set' do
           let(:full_options) do
             {


### PR DESCRIPTION
Since we require that the API key be of a Sensitive() type and we did
not have a good error message when the user provided us a value of a
different type, we now show a friendlier message early as to what is
wrong with the passed parameter.

### What ticket does this PR close?
Connected to #232 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation