### PR TITLE
144 Add warning when accessing non-https URLs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -145,5 +145,7 @@ Style/ClassAndModuleChildren:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
+Style/RedundantReturn:
+  Enabled: false
 Style/SymbolProc:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - If `authn_api_key` is not wrapped in `Sensitive` class, we now raise a descriptive
   error as to why we cannot proceed.
   [cyberark/conjur-puppet#232](https://github.com/cyberark/conjur-puppet/issues/232)
+- Warnings are now logged whenever this module attempts to use a non-HTTPS endpoint.
+  [cyberark/conjur-puppet#144](https://github.com/cyberark/conjur-puppet/issues/144)
 
 ## [3.0.0] - 2020-09-17
 


### PR DESCRIPTION
We want to notify the user that any communication over non-https links
is insecure so this change adds puppet warnings for any attempt at
accessing such endpoints.

### What ticket does this PR close?
Connected to #144 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation