### PR TITLE
Fix running Vagrant tests with compilation masters enabled

### DIFF
--- a/examples/puppetmaster/vagrant/3_run_puppet_agent.sh
+++ b/examples/puppetmaster/vagrant/3_run_puppet_agent.sh
@@ -13,7 +13,7 @@ snapshot_name="$(agent_snapshot_name $PUPPET_AGENT_VERSION)"
 
 echo "Locating relevant running containers..."
 conjur_cli_container=$(docker ps | awk '/.cyberark\/conjur-cli/{print $1}')
-puppet_master_container=$(docker ps | awk '/ puppet\/puppetserver/{print $1}')
+puppet_master_container=$(docker ps | grep -v 'compiler' | awk '/ puppet\/puppetserver/{print $1}')
 conjur_nginx_container=$(docker ps | awk '/ nginx:/{print $1}')
 
 echo "Using Puppet master container ID: $puppet_master_container"


### PR DESCRIPTION
Old code was unable to correctly filter multiple containers with
puppetserver image running concurrently so now we ensure that we filter
the resulting containers correctly.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation