### PR TITLE
Add ability to pass in authentication token in POST requests

### DIFF
--- a/lib/conjur/puppet_module/http.rb
+++ b/lib/conjur/puppet_module/http.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'conjur/puppet_module/ssl'
+require_relative 'ssl'
 
 module Conjur
   module PuppetModule
@@ -8,42 +8,42 @@ module Conjur
     module HTTP
       class << self
         def get(host_url, path, ssl_certificate, token)
-          uri, use_ssl = parse_url(host_url, path)
-          certs = Conjur::PuppetModule::SSL.load(ssl_certificate)
-
           headers = {}
           if token
             encoded_token = Base64.urlsafe_encode64(token)
             headers['Authorization'] = "Token token=\"#{encoded_token}\""
           end
 
-          Net::HTTP.start uri.host, uri.port, use_ssl: use_ssl, cert_store: certs do |http|
-            response = http.get(uri.request_uri, headers)
-
-            raise Net::HTTPError.new response.message, response unless response.code.match?(%r{^2})
-
-            response.body
+          start_http_request(host_url, path, ssl_certificate) do |http, uri|
+            http.get(uri.request_uri, headers)
           end
         end
 
-        def post(host_url, path, ssl_certificate, data)
-          uri, use_ssl = parse_url(host_url, path)
+        def post(host_url, path, ssl_certificate, data, token = nil)
+          headers = {}
+          if token
+            headers['Authorization'] = "Token token=\"#{token}\""
+          end
 
-          raise(ArgumentError, "POST data to #{uri} must not be empty!") \
-            if data.nil? || data.empty?
-
-          certs = Conjur::PuppetModule::SSL.load(ssl_certificate)
-
-          Net::HTTP.start uri.host, uri.port, use_ssl: use_ssl, cert_store: certs do |http|
-            response = http.post(uri.request_uri, data)
-
-            raise Net::HTTPError.new response.message, response unless response.code.match?(%r{^2})
-
-            response.body
+          start_http_request(host_url, path, ssl_certificate) do |http, uri|
+            http.post(uri.request_uri, data, headers)
           end
         end
 
         private
+
+        def start_http_request(host_url, path, ssl_certificate)
+          uri, use_ssl = parse_url(host_url, path)
+          certs = Conjur::PuppetModule::SSL.load(ssl_certificate)
+
+          Net::HTTP.start(uri.host, uri.port, use_ssl: use_ssl, cert_store: certs) do |http|
+            response = yield http, uri
+
+            raise Net::HTTPError.new response.message, response unless response.code.match?(%r{^2})
+
+            response.body
+          end
+        end
 
         def parse_url(url, path)
           url += '/' unless url.end_with? '/'

--- a/spec/unit/conjur/puppet_module/http_spec.rb
+++ b/spec/unit/conjur/puppet_module/http_spec.rb
@@ -22,6 +22,14 @@ describe Conjur::PuppetModule::HTTP do
 
   let(:ssl_certificate) { 'ssl_certificate' }
 
+  let(:token) { 'my_supersecret_token' }
+  let(:headers_with_token) do
+    { 'Authorization' => "Token token=\"#{token}\"" }
+  end
+  let(:headers_with_encoded_token) do
+    { 'Authorization' => 'Token token="bXlfc3VwZXJzZWNyZXRfdG9rZW4="' }
+  end
+
   let(:mock_return_data) { double('my_retrieved_data') }
   let(:mock_connection) { double('conjur_connection') }
   let(:mock_cert_store) { double('cert_store') }
@@ -45,13 +53,8 @@ describe Conjur::PuppetModule::HTTP do
   end
 
   describe 'get()' do
-    let(:token) { 'my_supersecret_token' }
-    let(:header_with_encoded_token) do
-      { 'Authorization' => 'Token token="bXlfc3VwZXJzZWNyZXRfdG9rZW4="' }
-    end
-
     it 'can retrieve data' do
-      expect(mock_connection).to receive(:get).with('/' + target_path, header_with_encoded_token)
+      expect(mock_connection).to receive(:get).with('/' + target_path, headers_with_encoded_token)
                                               .and_return(http_ok(mock_return_data))
 
       expect(subject.get(target_url, target_path, ssl_certificate, token))
@@ -59,7 +62,7 @@ describe Conjur::PuppetModule::HTTP do
     end
 
     it 'logs a warning on non-https URLs' do
-      expect(mock_connection).to receive(:get).with('/' + target_path, header_with_encoded_token)
+      expect(mock_connection).to receive(:get).with('/' + target_path, headers_with_encoded_token)
                                               .and_return(http_ok(mock_return_data))
 
       expect(Puppet).to receive(:warning)
@@ -71,7 +74,7 @@ describe Conjur::PuppetModule::HTTP do
     end
 
     it 'handles retrieval errors' do
-      expect(mock_connection).to receive(:get).with('/' + target_path, header_with_encoded_token)
+      expect(mock_connection).to receive(:get).with('/' + target_path, headers_with_encoded_token)
                                               .and_return(http_unauthorized)
 
       expect { subject.get(target_url, target_path, ssl_certificate, token) }
@@ -87,7 +90,7 @@ describe Conjur::PuppetModule::HTTP do
     end
 
     it 'can handle target url without slash' do
-      expect(mock_connection).to receive(:get).with('/' + target_path, header_with_encoded_token)
+      expect(mock_connection).to receive(:get).with('/' + target_path, headers_with_encoded_token)
                                               .and_return(http_ok(mock_return_data))
 
       expect(subject.get(target_url.delete_suffix('/'), target_path, ssl_certificate, token))
@@ -99,7 +102,7 @@ describe Conjur::PuppetModule::HTTP do
                                                hash_including(use_ssl: false,
                                                               cert_store: mock_cert_store))
                                          .and_yield(mock_connection)
-      expect(mock_connection).to receive(:get).with('/' + target_path, header_with_encoded_token)
+      expect(mock_connection).to receive(:get).with('/' + target_path, headers_with_encoded_token)
                                               .and_return(http_ok(mock_return_data))
 
       expect(subject.get(target_url.sub('https', 'http'), target_path, ssl_certificate, token))
@@ -118,15 +121,29 @@ describe Conjur::PuppetModule::HTTP do
     let(:mock_post_data) { 'post_data' }
 
     it 'can retrieve data' do
-      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data)
+      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data, {})
                                                .and_return(http_ok(mock_return_data))
 
       expect(subject.post(target_url, target_path, ssl_certificate, mock_post_data))
         .to eq(mock_return_data)
     end
 
+    it 'can forward the authorization token' do
+      expect(mock_connection).to receive(:post).with(
+        '/' + target_path,
+        mock_post_data,
+        headers_with_token,
+      ).and_return(http_ok(mock_return_data))
+
+      expect(subject.post(target_url,
+                          target_path,
+                          ssl_certificate,
+                          mock_post_data,
+                          token)).to eq(mock_return_data)
+    end
+
     it 'logs a warning on non-https URLs' do
-      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data)
+      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data, {})
                                                .and_return(http_ok(mock_return_data))
 
       expect(Puppet).to receive(:warning)
@@ -138,20 +155,15 @@ describe Conjur::PuppetModule::HTTP do
     end
 
     it 'handles retrieval errors' do
-      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data)
+      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data, {})
                                                .and_return(http_unauthorized)
 
       expect { subject.post(target_url, target_path, ssl_certificate, mock_post_data) }
         .to raise_error Net::HTTPError
     end
 
-    it 'raises an error if data is empty' do
-      expect { subject.post(target_url, target_path, ssl_certificate, nil) }
-        .to raise_error ArgumentError
-    end
-
     it 'can handle target url without slash' do
-      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data)
+      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data, {})
                                                .and_return(http_ok(mock_return_data))
 
       expect(subject.post(target_url.delete_suffix('/'), target_path, ssl_certificate, mock_post_data))
@@ -163,7 +175,7 @@ describe Conjur::PuppetModule::HTTP do
                                                hash_including(use_ssl: false,
                                                               cert_store: mock_cert_store))
                                          .and_yield(mock_connection)
-      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data)
+      expect(mock_connection).to receive(:post).with('/' + target_path, mock_post_data, {})
                                                .and_return(http_ok(mock_return_data))
 
       expect(subject.post(target_url.sub('https', 'http'), target_path, ssl_certificate, mock_post_data))


### PR DESCRIPTION
This will enable us to make POST requests that require authorization.
Even though it's not currently used, it will enable us to invoke API
endpoints that we were not able to use before.

### What ticket does this PR close?
Connected to #200

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation