### PR TITLE
Wrapped HTTP errors from Conjur in a descriptive error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-puppet#105](https://github.com/cyberark/conjur-puppet/issues/105)
 
 ### Changed
+- Conjur server errors now have better descriptions.
+  [cyberark/conjur-puppet#241](https://github.com/cyberark/conjur-puppet/issues/241)
 - If `authn_api_key` is not wrapped in `Sensitive` class, we now raise a descriptive
   error as to why we cannot proceed.
   [cyberark/conjur-puppet#232](https://github.com/cyberark/conjur-puppet/issues/232)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -10,10 +10,10 @@ What kind of error are you seeing?
 - [`Conjur configuration not found on system`](#identity-not-set)
 - [`Error while evaluating a Method call ... expects a Sensitive value, got Deferred`](#misuse-of-deferred-variables)
 - [`Failed to open TCP connection to ... (getaddrinfo: No such host is known.)`](#incorrect-conjur-endpoint)
-- [`Failed to apply catalog: Unauthorized`](#incorrect-conjur-credentials)
+- [`Conjur server error: Unauthorized`](#incorrect-conjur-credentials)
 - [`Could not find any pre-populated Conjur credentials in WinCred storage`](#wincred-credentials-not-correctly-set)
-- [`Failed to apply catalog: Not Found`](#variable-not-found)
-- [`SSL_connect returned=1 errno=0 state=error: certificate verify failed`](#incorrect-ssl-certificate)
+- [`Conjur server error: Not Found`](#variable-not-found)
+- [`Conjur server error: SSL_connect returned=1 errno=0 state=error: certificate verify failed`](#incorrect-ssl-certificate)
 - [`Cert file '/path/to/cert.pem' cannot be found!`](#certificate-path-cannot-be-used)
 - [`Value of 'authn_api_key' must be wrapped in 'Sensitive()'!`](#authn_api_key-not-wrapped-in-sensitive)
 
@@ -116,7 +116,7 @@ reachable.
 #### Symptoms
 - You see an error in your Puppet logs that looks something like:
   ```
-  Error: Failed to apply catalog: Unauthorized
+  Error: Failed to apply catalog: Conjur server error: Unauthorized
   ```
 
 #### Known Causes
@@ -135,7 +135,7 @@ correct for the server that you are trying to connect to.
   ```
   Warning: Could not find any pre-populated Conjur credentials in WinCred storage for https://conjur.cyberark.com
   ...
-  Error: Failed to apply catalog: POST data to https://conjur.cyberark.com/authn/myaccount//authenticate must not be empty!
+  Error: Failed to apply catalog: Conjur server error: POST data to https://conjur.cyberark.com/authn/myaccount//authenticate must not be empty!
   ```
 
 #### Known Causes
@@ -155,7 +155,7 @@ Ensure that you have the correct credentials set in `Windows Credentials` for th
   ```
   Debug: Fetching Conjur secret 'inventoryy/db-password'...
   ...
-  Error: Failed to apply catalog: Not Found
+  Error: Failed to apply catalog: Conjur server error: Not Found
   ```
 
 #### Known Causes
@@ -172,7 +172,7 @@ user configured has the permissions to retrieve it.
 #### Symptoms
 - You see an error in your Puppet logs that looks something like:
   ```
-  Error: Failed to apply catalog: SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)
+  Error: Failed to apply catalog: Conjur server error: SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)
   ```
 
 #### Known Causes

--- a/lib/conjur/puppet_module/http.rb
+++ b/lib/conjur/puppet_module/http.rb
@@ -39,7 +39,9 @@ module Conjur
           Net::HTTP.start(uri.host, uri.port, use_ssl: use_ssl, cert_store: certs) do |http|
             response = yield http, uri
 
-            raise Net::HTTPError.new response.message, response unless response.code.match?(%r{^2})
+            unless response.code.match?(%r{^2})
+              raise Net::HTTPError.new("Conjur server error: #{response.message}", response)
+            end
 
             response.body
           end

--- a/spec/unit/conjur/puppet_module/http_spec.rb
+++ b/spec/unit/conjur/puppet_module/http_spec.rb
@@ -78,7 +78,7 @@ describe Conjur::PuppetModule::HTTP do
                                               .and_return(http_unauthorized)
 
       expect { subject.get(target_url, target_path, ssl_certificate, token) }
-        .to raise_error Net::HTTPError
+        .to raise_error Net::HTTPError, %r{Conjur server error: unauthorized}
     end
 
     it 'does not include token if none is provided' do
@@ -159,7 +159,7 @@ describe Conjur::PuppetModule::HTTP do
                                                .and_return(http_unauthorized)
 
       expect { subject.post(target_url, target_path, ssl_certificate, mock_post_data) }
-        .to raise_error Net::HTTPError
+        .to raise_error Net::HTTPError, %r{Conjur server error: unauthorized}
     end
 
     it 'can handle target url without slash' do


### PR DESCRIPTION
This will allow for easier troubleshooting since it will indicate that
the error seen is from the server and not from the conjur module itself.

### What ticket does this PR close?
Resolves #241 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation