### PR TITLE
Add workaround for broken upstream PDK image

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,12 +3,17 @@
 # To ensure this script always executes relative to the repo root
 cd "$(dirname "$0")/.."
 
+docker build -t puppet-pdk -f ./ci/Dockerfile.pdk .
+
 if [ ! "${SKIP_VALIDATION}" == "true" ]; then
   echo "Running validations..."
   docker run --rm \
     -v $PWD:/root \
     -w /root \
-    puppet/pdk validate control-repo,metadata,puppet,ruby,yaml
+    puppet-pdk \
+    bash -ec "
+      pdk validate control-repo,metadata,puppet,ruby,yaml
+    "
 fi
 
 echo "Running specs..."
@@ -16,5 +21,9 @@ mkdir -p ./spec/output
 docker run --rm \
   -v $PWD:/root \
   -w /root \
-  puppet/pdk test unit --format=junit:./spec/output/rspec.xml --format=text
+  puppet-pdk \
+  bash -ec "
+    pdk test unit --format=junit:./spec/output/rspec.xml --format=text
+  "
+
 echo "Tests complete!"


### PR DESCRIPTION
This workaround for cyberark/conjur-puppet/issues/246 uses our
own PDK tool image instead of `puppet/pdk` until upstream issue
https://github.com/puppetlabs/pdk-docker/issues/12 is fixed.

### What ticket does this PR close?
Resolves #246 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation