### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     + [Conjur Enterprise v4](#conjur-enterprise-v4)
     + [Use of Host Factory Tokens](#use-of-host-factory-tokens)
   * [Installation](#installation)
-  * [Using conjur-puppet with Conjur OSS](#using-conjur-puppet-with-conjur-oss)
+  * [Using conjur-puppet with Conjur Open Source](#using-conjur-puppet-with-conjur-open-source)
   * [Conjur module basics](#conjur-module-basics)
     + [Example usage](#example-usage)
     + [`Deferred` functions](#deferred-functions)
@@ -46,8 +46,8 @@ You can find our official distributable releases on Puppet Forge under [`cyberar
 
 ![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D?link=https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md)
 
-This repo is a **Certified** project. It is officially approved to work with Conjur OSS
-and DAP as documented. For more detailed information on our certification levels, see
+This repo is a **Certified** project. It is officially approved to work with Conjur Open Source
+and Conjur Enterprise as documented. For more detailed information on our certification levels, see
 [our community guidelines](https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md#community).
 
 ## Setup
@@ -58,8 +58,8 @@ This module requires that you have:
 - Puppet v6 _or equivalent EE version_
 - Conjur endpoint available to both the Puppet server and the Puppet nodes using this
   module. Supported versions:
-  - Conjur OSS v1+
-  - DAP v10+
+  - Conjur Open Source v1+
+  - Conjur Enterprise (formerly DAP) v10+
 
 ### Deprecations
 
@@ -97,9 +97,9 @@ command on the Puppet server:
 puppet module install cyberark-conjur --version 1.2.3
 ```
 
-### Using conjur-puppet with Conjur OSS
+### Using conjur-puppet with Conjur Open Source
 
-Are you using this project with [Conjur OSS](https://github.com/cyberark/conjur)? Then we
+Are you using this project with [Conjur Open Source](https://github.com/cyberark/conjur)? Then we
 **strongly** recommend choosing the version of this project to use from the latest [Conjur OSS
 suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html).
 Conjur maintainers perform additional testing on the suite release versions to ensure
@@ -261,15 +261,15 @@ In the sections below, we'll outline the different methods of providing this
 module with your Conjur configuration and credentials. In those sections we'll
 refer often to the following Conjur configuration variables:
 
-- `appliance_url`: The URL of the Conjur or DAP instance you are connecting to. If using
-  DAP, this may be the URL of a load balancer for the cluster's DAP follower instances.
-- `account` - the account name for the Conjur / DAP instance you are connecting to.
-- `authn_login`: The identity you are using to authenticate to the Conjur / DAP
+- `appliance_url`: The URL of the Conjur or Conjur Enterprise instance you are connecting to. If using
+  Conjur Enterprise, this may be the URL of a load balancer for the cluster's Conjur Enterprise follower instances.
+- `account` - the account name for the Conjur / Conjur Enterprise instance you are connecting to.
+- `authn_login`: The identity you are using to authenticate to the Conjur / Conjur Enterprise
   instance. For hosts / application identities, the fully qualified path should be prefixed
   by `host/`, eg `host/production/my-app-host`.
 - `authn_api_key`: The API key of the identity you are using to authenticate to the
-  Conjur / DAP instance.
-- `ssl_certificate`: The _raw_ PEM-encoded x509 CA certificate chain for the DAP instance you
+  Conjur / Conjur Enterprise instance.
+- `ssl_certificate`: The _raw_ PEM-encoded x509 CA certificate chain for the Conjur Enterprise instance you
   are connecting to, provided as a string (including newlines) or using the
   [Puppet file resource type](https://puppet.com/docs/puppet/latest/types/file.html).
   This value may be obtained by running the command:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,7 +10,7 @@
 
 ### Functions
 
-* [`conjur::secret`](#conjursecret): Function to retrieve a Conjur / DAP secret
+* [`conjur::secret`](#conjursecret): Function to retrieve a Conjur secret
 
 ## Resource types
 
@@ -32,11 +32,11 @@ Default value: `present`
 
 ##### `username`
 
-The identity used to authenticate to the Conjur / DAP instance
+The identity used to authenticate to the Conjur instance
 
 ##### `value`
 
-The API key matching the Conjur / DAP identity
+The API key matching the Conjur identity
 
 #### Parameters
 
@@ -49,7 +49,7 @@ discover the appropriate provider for your platform.
 
 ##### `target`
 
-Conjur / DAP URL
+Conjur URL
 
 ## Functions
 
@@ -57,7 +57,7 @@ Conjur / DAP URL
 
 Type: Ruby 4.x API
 
-Function to retrieve a Conjur / DAP secret
+Function to retrieve a Conjur secret
 
 #### Examples
 
@@ -87,7 +87,7 @@ $dbpass = Deferred(conjur::secret, ['production/postgres/password', {
 
 #### `conjur::secret(String $variable_id, Optional[Hash] $options)`
 
-Function to retrieve a Conjur / DAP secret
+Function to retrieve a Conjur secret
 
 Returns: `Sensitive` Value of the Conjur variable.
 
@@ -121,7 +121,7 @@ $dbpass = Deferred(conjur::secret, ['production/postgres/password', {
 
 Data type: `String`
 
-Conjur / DAP variable ID that you want the value of.
+Conjur variable ID that you want the value of.
 
 ##### `options`
 
@@ -129,11 +129,11 @@ Data type: `Optional[Hash]`
 
 Optional parameter specifying server identity overrides
 The following keys are supported in the options hash:
-- appliance_url: The URL of the Conjur or DAP instance..
+- appliance_url: The URL of the Conjur instance..
 - account: Name of the Conjur account that contains this variable.
-- authn_login: The identity you are using to authenticate to the Conjur / DAP instance.
+- authn_login: The identity you are using to authenticate to the Conjur instance.
 - authn_api_key: The API key of the identity you are using to authenticate with (must be Sensitive type).
-- cert_file: The absolute path to CA certificate chain for the DAP instance on the agent. This variable overrides `ssl_certificate`.
-- ssl_certificate: The _raw_ PEM-encoded x509 CA certificate chain for the DAP instance. Overwritten by the contents read from `cert_file` when it is present.
+- cert_file: The absolute path to CA certificate chain for the Conjur Enterprise instance on the agent. This variable overrides `ssl_certificate`.
+- ssl_certificate: The _raw_ PEM-encoded x509 CA certificate chain for the Conjur Enterprise instance. Overwritten by the contents read from `cert_file` when it is present.
 - version: Conjur API version, defaults to 5.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -103,7 +103,7 @@ information on how to do this correctly.
   ```
 
 #### Known Causes
-This problem occurs when the `appliance_url` for Conjur / DAP is either
+This problem occurs when the `appliance_url` for Conjur is either
 incorrect or unreachable from the agent.
 
 #### Resolution
@@ -121,7 +121,7 @@ reachable.
 
 #### Known Causes
 This is usually due to credential values being incorrect for the
-target Conjur / DAP server.
+target Conjur server.
 
 #### Resolution
 Verify that `authn_login_id`, `authn_api_key`, and `account` are
@@ -180,7 +180,7 @@ The provided Conjur SSL signing certificate is either incorrect, invalid, or mal
 
 #### Resolution
 Ensure that `ssl_certificate` or `cert_file` correctly specifies the certificate
-that can be used to validate the Conjur / DAP SSL certificate. Also ensure that
+that can be used to validate the Conjur SSL certificate. Also ensure that
 none of the certificates in the chain are expired as seen by the agent machine.
 
 


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
