### PR TITLE
Fix bug in PDK validate/test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 .project
 .envrc
 /inventory.yaml
+pdk.yaml
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Upgrade PDK and Ruby base image version
+  [cyberark/conjur-puppet#253](https://github.com/cyberark/conjur-puppet/pull/253)
+
 ## [3.1.0] - 2020-10-08
 
 ### Added

--- a/ci/Dockerfile.pdk
+++ b/ci/Dockerfile.pdk
@@ -1,11 +1,13 @@
-FROM ruby:2.5
-MAINTAINER CyberArk Software Ltd.
+FROM ruby:3.2.1
+LABEL org.opencontainers.image.authors="CyberArk Software Ltd."
 
 # Install PDK (https://puppet.com/docs/pdk/1.x/pdk_install.html)
-RUN wget -q https://apt.puppet.com/puppet-tools-release-stretch.deb && \
-    dpkg -i puppet-tools-release-stretch.deb && \
+RUN wget "https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=debian&rel=10&arch=amd64&ver=latest" -O pdk.deb && \
+    dpkg -i pdk.deb && \
     apt-get update && \
-    apt-get install pdk
+    apt-get install -y pdk
+
+RUN ln -s /bin/mkdir /usr/bin/mkdir
 
 RUN mkdir /conjur
 WORKDIR /conjur

--- a/ci/expose-daemon.ps1
+++ b/ci/expose-daemon.ps1
@@ -133,6 +133,15 @@ function updateConfig($daemonJson, $serverCertsPath) {
 $dockerData = "$env:ProgramData\docker"
 $userPath = "$env:USERPROFILE\.docker"
 
+Write-Host "Updating and Restarting Docker"
+
+Stop-Service docker
+Remove-Item -Recurse -Force $dockerData
+Invoke-WebRequest https://get.docker.com/builds/Windows/x86_64/docker-1.13.1.zip -UseBasicParsing -OutFile docker.zip
+Expand-Archive docker.zip -DestinationPath $Env:ProgramFiles -Force
+Remove-Item -Force docker.zip
+Start-Service docker
+
 ensureDirs @("$dockerData\certs.d", "$dockerData\config", "$userPath")
 
 $serverCertsPath = "$dockerData\certs.d"

--- a/examples/puppetmaster/code/environments/production/manifests/site.pp
+++ b/examples/puppetmaster/code/environments/production/manifests/site.pp
@@ -37,7 +37,7 @@ node default {
   file { $output_file2:
     ensure  => file,
     content => Sensitive(Deferred(conjur::secret, [
-          'inventory/funky/special @#$%^&*(){}[].,+/variable'
+          'inventory/funky/special @#$%^&*(){}[].,+/variable',
     ])),
   }
 

--- a/examples/puppetmaster/test.sh
+++ b/examples/puppetmaster/test.sh
@@ -151,6 +151,7 @@ run_with_docker_windows() {
   export DOCKER_HOST;
   export DOCKER_CERT_PATH;
   export DOCKER_TLS_VERIFY;
+  export DOCKER_BUILDKIT=0
 
   "$@"
 }


### PR DESCRIPTION
### Desired Outcome
The version of puppet included with PDK (6.27.0) is broken due to a change in concurrent-ruby. It appears to be fixed in Puppet 6.29.0, so update the dockerfile to fetch a newer version of PDK

See: https://github.com/ruby-concurrency/concurrent-ruby/pull/988
Fixed by: https://github.com/puppetlabs/puppet/pull/8996

Also address dev tasks around updating Docker base images and upgrading to Ruby 3.

### Implemented Changes

- Run `pdk validate` and `test ` against a more recent version of Puppet with the fix
- Update docker base images
- Fix Windows docker builds by disabling buildkit

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
