### PR TITLE
Upgrade ruby to 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Security
+- Upgrade PDK and Ruby base image version to 3.2.2
+  [cyberark/conjur-puppet#256](https://github.com/cyberark/conjur-puppet/pull/256)
 - Upgrade PDK and Ruby base image version
   [cyberark/conjur-puppet#253](https://github.com/cyberark/conjur-puppet/pull/253)
 

--- a/ci/Dockerfile.pdk
+++ b/ci/Dockerfile.pdk
@@ -1,4 +1,4 @@
-FROM ruby:3.2.1
+FROM ruby:3.2.2
 LABEL org.opencontainers.image.authors="CyberArk Software Ltd."
 
 # Install PDK (https://puppet.com/docs/pdk/1.x/pdk_install.html)


### PR DESCRIPTION
### Desired Outcome

This pull request upgrades ruby from 3.2.1 to ruby 3.2.2. Upgrading to 3.2-slim does not seem to be feasible as it caused the build to fail.

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [X] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
