### PR TITLE
Skip validate

### DIFF
--- a/ci/release.sh
+++ b/ci/release.sh
@@ -16,6 +16,7 @@ summon -f ./ci/secrets.yml \
     bash -ec """
       PDK_DISABLE_ANALYTICS=true pdk release --skip-documentation \
                                              --skip-changelog \
+                                             --skip-validation \
                                              --forge-token="\$PDK_FORGE_TOKEN" \
                                              --force
     """


### PR DESCRIPTION
The `pdk validate` step in the release process fails on Ruby validation but provides no output:
```
pdk (INFO): Using Ruby 3.2.2
pdk (INFO): Using Puppet 8.1.0
[✔] Installing missing Gemfile dependencies.
pdk (INFO): Validator 'puppet-plan-syntax' skipped for '/conjur'. No files matching '["plans/**/*.pp"]' found to validate.
pdk (INFO): Validator 'puppet-epp' skipped for '/conjur'. No files matching '["**/*.epp"]' found to validate.
pdk (INFO): Validator 'task-name' skipped for '/conjur'. No files matching '["tasks/**/*"]' found to validate.
pdk (INFO): Validator 'task-metadata-lint' skipped for '/conjur'. No files matching '["tasks/*.json"]' found to validate.
┌ [✔] Running metadata validators ...
├── [✔] Checking metadata syntax (metadata.json tasks/*.json).
└── [✔] Checking module metadata style (metadata.json).
┌ [✔] Running puppet validators ...
├── [✔] Checking Puppet manifest syntax (**/*.pp).
└── [✔] Checking Puppet manifest style (**/*.pp).
┌ [✖] Running ruby validators ...
└── [✖] Checking Ruby code style (**/**.rb).
┌ [✔] Running tasks validators ...
├── [✔] Checking task names (tasks/**/*).
└── [✔] Checking task metadata style (tasks/*.json).
┌ [✔] Running yaml validators ...
└── [✔] Checking YAML syntax (**/*.yaml **/*.yml).
pdk (ERROR): An error occured during validation
```

Disable this since no manual code changes have been made in the repo, and there are no actionable changes in the output.