### PR TITLE
Bump upper bound for registry version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.1.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Release step still fails since the newer version of PDK is pulling in the `puppetlabs/registry` dependency at v5.1.0 by default.
