### PR TITLE
CONJSE-1877: Update Ruby base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Upgrade Ruby base image version to 3.3-slim
+  [cyberark/conjur-puppet#263](https://github.com/cyberark/conjur-puppet/pull/263)
+
 ## [3.1.1] - 2023-08-23
 
 ### Security

--- a/ci/Dockerfile.pdk
+++ b/ci/Dockerfile.pdk
@@ -1,4 +1,4 @@
-FROM ruby:3.3-rc-slim
+FROM ruby:3.3-slim
 LABEL org.opencontainers.image.authors="CyberArk Software Ltd."
 
 # Install PDK (https://puppet.com/docs/pdk/1.x/pdk_install.html)


### PR DESCRIPTION
### Desired Outcome

Snyk is flagging the base image in cyberark/conjur-puppet/ci/Dockerfile.pdk as vulnerable. It's currently using ruby:3.3-rc-slim, and should be updated to at least ruby:3.3.2-slim.

### Implemented Changes

- Updated to ruby:3.3-slim

### Connected Issue/Story

CyberArk internal issue ID: CONJSE-1877

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
